### PR TITLE
Add error on cyclic dependencies to avoid infinite loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Add error if a cyclical dependency is detected to avoid infinite loop
 
 ## 0.23.2 - 2021-11-30
 ### Changed

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -109,7 +109,7 @@ pub fn main() -> Result<()> {
         debugln!("main: lockfile {:?} up-to-date", lock_path);
         locked_existing.unwrap()
     };
-    sess.load_locked(&locked);
+    sess.load_locked(&locked)?;
 
     // Ensure the locally linked packages are up-to-date.
     {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -218,6 +218,13 @@ impl<'ctx> DependencyResolver<'ctx> {
                     name, manifest.package.name
                 )));
             }
+            if name == manifest.package.name {
+                return Err(Error::new(format!(
+                    "Please ensure no packages with same name as calling package\n\
+                    \tCurrently {} is called in {}",
+                    name, manifest.package.name
+                )));
+            }
             self.register_dependency(name, id, versions[&id].clone());
         }
         Ok(())

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -211,6 +211,13 @@ impl<'ctx> DependencyResolver<'ctx> {
 
         // Register the versions.
         for (name, id) in names {
+            if name == self.sess.manifest.package.name {
+                return Err(Error::new(format!(
+                    "Please ensure no packages with same name as top package\n\
+                    \tCurrently {} is called in {}",
+                    name, manifest.package.name
+                )));
+            }
             self.register_dependency(name, id, versions[&id].clone());
         }
         Ok(())

--- a/src/sess.rs
+++ b/src/sess.rs
@@ -138,7 +138,7 @@ impl<'sess, 'ctx: 'sess> Session<'ctx> {
     ///
     /// This internalizes the dependency sources, i.e. assigns `DependencyRef`
     /// objects to them, and generates a nametable.
-    pub fn load_locked(&self, locked: &config::Locked) {
+    pub fn load_locked(&self, locked: &config::Locked) -> Result<()> {
         let mut deps = self.deps.lock().unwrap();
         let mut names = HashMap::new();
         let mut graph_names = HashMap::new();
@@ -218,6 +218,7 @@ impl<'sess, 'ctx: 'sess> Session<'ctx> {
         *self.names.lock().unwrap() = names;
         *self.graph.lock().unwrap() = Arc::new(graph);
         *self.pkgs.lock().unwrap() = Arc::new(pkgs);
+        Ok(())
     }
 
     /// Obtain information on a dependency.


### PR DESCRIPTION
Currently, if a dependency calls itself (or a different dependency subsequently calling itself, or further chains), this creates a dependency loop and results in an infinite loop within bender. This PR returns an error if cyclical dependencies are detected, with hints where to find the issue.