### PR TITLE
Wrap defines in quotes for the VCS's shell script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Add `clone` command to checkout individual ips to a directory and create a path reference in Bender.local
 - Add `parents` command to get list of packages requiring the queried package
 
+### Changed
+- Wrap defines in quotes for the VCS's shell script
+
 ### Fixed
 - Fix plugins to work for scripts in root repository
 - Force git fetch on unsatisfied requirements to check for newly added tags in server repository

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -441,7 +441,9 @@ fn emit_vcs_sh(
                             let mut s = format!("+define+{}", k.to_uppercase());
                             if let Some(v) = v {
                                 s.push('=');
+                                s.push('"');
                                 s.push_str(&v);
+                                s.push('"');
                             }
                             lines.push(s);
                         }


### PR DESCRIPTION
Since VCS generates a shell script, we have to wrap the defines in quotes for this case to allow defines like `32'h80000000`. Otherwise, the `'` breaks the shell script.