### PR TITLE
CI improve

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.44.0 # minimum supported version
+          - 1.46.0 # minimum supported version
     continue-on-error: ${{ matrix.rust == 'nightly' }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,12 @@ jobs:
           toolchain: ${{ matrix.rust}}
           override: true
           components: rustfmt
-      - name: Test
+      - name: Build
         run: cargo build
-      - run: cargo test --all
-      - run: cargo fmt -- --check
-      - run: tests/run_all.sh
+      - name: Cargo Test
+        run: cargo test --all
+      - name: Format (fix with `cargo fmt`)
+        run: cargo fmt -- --check
+      - name: Run unit-tests
+        run: tests/run_all.sh
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         rust:
           - stable


### PR DESCRIPTION
Update CI tests:
- do not cancel jobs if one fails
- Update minimum Rust version to 1.46.0 (due to `bitflags` dependency)
- Properly name tests