### PR TITLE
Add error handling on dependency mismatch (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## Unreleased
 ### Added
 - Add error if a cyclical dependency is detected to avoid infinite loop
+- Add error on dependency mismatch between `Bender.yml` and `Bender.lock`
 
 ## 0.23.2 - 2021-11-30
 ### Changed

--- a/src/sess.rs
+++ b/src/sess.rs
@@ -178,6 +178,15 @@ impl<'sess, 'ctx: 'sess> Session<'ctx> {
             let mut ranks: HashMap<DependencyRef, usize> =
                 graph.keys().map(|&id| (id, 0)).collect();
             let mut pending = HashSet::new();
+            for name in self.manifest.dependencies.keys() {
+                if !(names.contains_key(name)) {
+                    return Err(Error::new(format!(
+                        "`Bender.yml` contains dependency `{}` but `Bender.lock` does not.\n\
+                        \tYou may need to run `bender update`.",
+                        name
+                    )));
+                }
+            }
             pending.extend(self.manifest.dependencies.keys().map(|name| names[name]));
             let mut cyclic = false;
             while !pending.is_empty() {


### PR DESCRIPTION
After updating `Bender.yml` with a new dependency not in `Bender.lock`, an error will be returned suggesting to run `bender update` instead of bender panicking without indication what the problem is.