### PR TITLE
CI: Release for all currently supported Ubuntu versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,10 +23,10 @@ jobs:
           - centos:8.2.2004
           - centos:8.3.2011
           - centos:8.4.2105
-          - ubuntu:16.04
           - ubuntu:18.04
           - ubuntu:20.04
-          - ubuntu:20.10
+          - ubuntu:21.04
+          - ubuntu:21.10
           - fedora:34
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Drop support for 16.04 LTS and 20.10, both of which have reached EOL, and add 21.04 and 21.10.

Closes #56.