### PR TITLE
Improve git handling for issue (#52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Added
 - Add error if a cyclical dependency is detected to avoid infinite loop
 - Add error on dependency mismatch between `Bender.yml` and `Bender.lock`
+- Add hint to work around the "too many open files" error (issue #52).
 
 ## 0.23.2 - 2021-11-30
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Add error on dependency mismatch between `Bender.yml` and `Bender.lock`
 - Add hint to work around the "too many open files" error (issue #52).
 
+### Changed
+- Reduce the number of open files in large repositories by changing the method to get the Git commit hash from a tag (from individual calls to `git rev-parse --verify HASH^{commit}` to `git show-ref --dereference`).
+
 ## 0.23.2 - 2021-11-30
 ### Changed
 - Wrap defines in quotes for the VCS's shell script

--- a/src/git.rs
+++ b/src/git.rs
@@ -150,29 +150,35 @@ impl<'git, 'io, 'sess: 'io, 'ctx: 'sess> Git<'io, 'sess, 'ctx> {
     /// List all refs and their hashes.
     pub fn list_refs(self) -> GitFuture<'io, Vec<(String, String)>> {
         Box::new(
-            self.spawn_unchecked_with(|c| c.arg("show-ref"))
+            self.spawn_unchecked_with(|c| c.arg("show-ref").arg("--dereference"))
                 .and_then(move |raw| {
-                    future::join_all(
-                        raw.lines()
-                            .map(|line| {
-                                // Parse the line.
-                                let mut fields = line.split_whitespace().map(String::from);
-                                // TODO: Handle the case where the line might not contain enough
-                                // information or is missing some fields.
-                                let mut rev = fields.next().unwrap();
-                                let rf = fields.next().unwrap();
-                                rev.push_str("^{commit}");
-
-                                // Parse the ref. This is needed since the ref for an annotated
-                                // tag points to the hash of the tag itself, rather than the
-                                // underlying commit. By calling `git rev-parse` with the ref
-                                // augmented with `^{commit}`, we can ensure that we always end
-                                // up with a commit hash.
-                                self.spawn_with(|c| c.arg("rev-parse").arg("--verify").arg(rev))
-                                    .map(|rev| (rev.trim().into(), rf))
-                            })
-                            .collect::<Vec<_>>(),
-                    )
+                    let mut all_revs = raw
+                        .lines()
+                        .map(|line| {
+                            // Parse the line
+                            let mut fields = line.split_whitespace().map(String::from);
+                            let rev = fields.next().unwrap();
+                            let rf = fields.next().unwrap();
+                            (rev, rf)
+                        })
+                        .collect::<Vec<_>>();
+                    // Ensure only commit hashes are returned by using dereferenced values in case they exist
+                    let deref_revs = all_revs
+                        .clone()
+                        .into_iter()
+                        .filter(|tup| tup.1.ends_with("^{}"));
+                    for item in deref_revs {
+                        let index = all_revs
+                            .iter()
+                            .position(|x| *x.1 == item.1.replace("^{}", ""))
+                            .unwrap();
+                        all_revs.remove(index);
+                        let index = all_revs.iter().position(|x| *x.1 == item.1).unwrap();
+                        all_revs.remove(index);
+                        all_revs.push((item.0, item.1.replace("^{}", "")));
+                    }
+                    // Return future
+                    future::ok(all_revs)
                 }),
         )
     }


### PR DESCRIPTION
- Add hint for workaround in issue (#52)
- Change method to get git commit hash from tag (use `git show-ref --dereference` instead of `git rev-parse
--verify HASH^{commit}`). Reduces number of concurrent commands to improve situation for (#52).