### PR TITLE
Add warning for name mismatch of dependency and package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Add error if a cyclical dependency is detected to avoid infinite loop
 - Add error on dependency mismatch between `Bender.yml` and `Bender.lock`
 - Add hint to work around the "too many open files" error (issue #52).
+- Add warning for mismatch of dependency name and name in package
 
 ### Changed
 - Reduce the number of open files in large repositories by changing the method to get the Git commit hash from a tag (from individual calls to `git rev-parse --verify HASH^{commit}` to `git show-ref --dereference`).

--- a/src/sess.rs
+++ b/src/sess.rs
@@ -854,7 +854,13 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
                 let manifest_path = path.join("Bender.yml");
                 if manifest_path.exists() {
                     match read_manifest(&manifest_path) {
-                        Ok(m) => Box::new(future::ok(Some(self.sess.intern_manifest(m)))),
+                        Ok(m) => {
+                            if dep.name != m.package.name {
+                                warnln!("Dependency name and package name do not match for {:?} / {:?}, this can cause unwanted behavior",
+                                    dep.name, m.package.name);
+                            }
+                            Box::new(future::ok(Some(self.sess.intern_manifest(m))))
+                        }
                         Err(e) => Box::new(future::err(e)),
                     }
                 } else {
@@ -914,6 +920,16 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
                                 .lock()
                                 .unwrap()
                                 .insert(cache_key, manifest);
+                            if dep.name != match manifest {
+                                Some(x) => &x.package.name,
+                                None => "dead"
+                            } {
+                                warnln!("Dependency name and package name do not match for {:?} / {:?}, this can cause unwanted behavior",
+                                    dep.name, match manifest {
+                                        Some(x) => &x.package.name,
+                                        None => "dead"
+                                    });
+                            }
                             Ok(manifest)
                         }),
                 )


### PR DESCRIPTION
A naming mismatch can currently cause issues, e.g. when using the parents command to identify packages. May be changed to an error in the future to enforce correct behavior.