### PR TITLE
Add arguments to manage git fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Add warning for mismatch of dependency name and name in package
 - Add dependency information to `sources` command
 - Add `--fetch/-f` argument to `bender update` to force re-fetch of git dependencies from their remotes
+- Add global `--local` argument to disable remote accesses of git commands, e.g. for air-gapped computers
 
 ### Changed
 - Reduce the number of open files in large repositories by changing the method to get the Git commit hash from a tag (from individual calls to `git rev-parse --verify HASH^{commit}` to `git show-ref --dereference`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Add hint to work around the "too many open files" error (issue #52).
 - Add warning for mismatch of dependency name and name in package
 - Add dependency information to `sources` command
+- Add `--fetch/-f` argument to `bender update` to force re-fetch of git dependencies from their remotes
 
 ### Changed
 - Reduce the number of open files in large repositories by changing the method to get the Git commit hash from a tag (from individual calls to `git rev-parse --verify HASH^{commit}` to `git show-ref --dereference`).

--- a/README.md
+++ b/README.md
@@ -394,6 +394,8 @@ Supported formats:
 
 Whenever you update the list of dependencies, you likely have to run `bender update` to re-resolve the dependency versions, and recreate the `Bender.lock` file.
 
+Calling update with the `--fetch/-f` flag will force all git dependencies to be re-fetched from their corresponding urls.
+
 > Note: Actually this should be done automatically if you add a new dependency. But due to the lack of coding time, this has to be done manually as of now.
 
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,7 +33,16 @@ pub fn main() -> Result<()> {
                 .global(true)
                 .help("Sets a custom root working directory"),
         )
-        .subcommand(SubCommand::with_name("update").about("Update the dependencies"))
+        .subcommand(
+            SubCommand::with_name("update")
+                .about("Update the dependencies")
+                .arg(
+                    Arg::with_name("fetch")
+                        .short("f")
+                        .long("fetch")
+                        .help("forces fetch of git dependencies"),
+                ),
+        )
         .subcommand(cmd::path::new())
         .subcommand(cmd::parents::new())
         .subcommand(cmd::clone::new())
@@ -62,6 +71,14 @@ pub fn main() -> Result<()> {
         ENABLE_DEBUG.store(true, std::sync::atomic::Ordering::Relaxed);
     }
 
+    let mut force_fetch = false;
+    match matches.subcommand() {
+        ("update", Some(matches)) => {
+            force_fetch = matches.is_present("fetch");
+        }
+        _ => {}
+    }
+
     // Determine the root working directory, which has either been provided via
     // the -d/--dir switch, or by searching upwards in the file system
     // hierarchy.
@@ -85,7 +102,7 @@ pub fn main() -> Result<()> {
 
     // Assemble the session.
     let sess_arenas = SessionArenas::new();
-    let sess = Session::new(&root_dir, &manifest, &config, &sess_arenas);
+    let sess = Session::new(&root_dir, &manifest, &config, &sess_arenas, force_fetch);
 
     // Read the existing lockfile.
     let lock_path = root_dir.join("Bender.lock");

--- a/src/cmd/clone.rs
+++ b/src/cmd/clone.rs
@@ -134,15 +134,19 @@ pub fn run(sess: &Session, path: &Path, matches: &ArgMatches) -> Result<()> {
             Err(Error::new(format!("git adding remote failed")))?;
         }
 
-        if !Command::new(&sess.config.git)
-            .arg("fetch")
-            .arg("--all")
-            .current_dir(path.join(path_mod).join(dep))
-            .status()
-            .unwrap()
-            .success()
-        {
-            Err(Error::new(format!("git fetch failed")))?;
+        if !sess.local_only {
+            if !Command::new(&sess.config.git)
+                .arg("fetch")
+                .arg("--all")
+                .current_dir(path.join(path_mod).join(dep))
+                .status()
+                .unwrap()
+                .success()
+            {
+                Err(Error::new(format!("git fetch failed")))?;
+            }
+        } else {
+            warnln!("fetch not performed due to --local argument.");
         }
 
         println!(

--- a/src/sess.rs
+++ b/src/sess.rs
@@ -79,13 +79,20 @@ impl<'sess, 'ctx: 'sess> Session<'ctx> {
         manifest: &'ctx Manifest,
         config: &'ctx Config,
         arenas: &'ctx SessionArenas,
+        force_fetch: bool,
     ) -> Session<'ctx> {
         Session {
             root: root,
             manifest: manifest,
             config: config,
             arenas: arenas,
-            manifest_mtime: try_modification_time(root.join("Bender.yml")),
+            manifest_mtime: {
+                if force_fetch {
+                    Some(SystemTime::now())
+                } else {
+                    try_modification_time(root.join("Bender.yml"))
+                }
+            },
             stats: Default::default(),
             deps: Mutex::new(DependencyTable::new()),
             paths: Mutex::new(HashSet::new()),


### PR DESCRIPTION
- `bender update --fetch` forces a re-fetch of the git dependencies
- `bender --local` disables fetching of remote repositories to avoid internet access