### PR TITLE
Fix panic when calling parents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Changed
 - Interpret all dependency names as lowercase to reduce ambiguity
 
+### Fixed
+- Fix panic of `parents` command if a dependency does not have a manifest
+
 ## 0.24.0 - 2022-01-06
 ### Added
 - Add error if a cyclical dependency is detected to avoid infinite loop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Interpret all dependency names as lowercase to reduce ambiguity
 
 ### Fixed
-- Fix panic of `parents` command if a dependency does not have a manifest
+- Fix panic of `parents` command if a dependency does not have a manifest or if the manifest does not match the `Bender.lock` file.
 
 ## 0.24.0 - 2022-01-06
 ### Added

--- a/src/cmd/parents.rs
+++ b/src/cmd/parents.rs
@@ -45,7 +45,12 @@ pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
             let all_deps = deps.iter().map(|&id| sess.dependency(id));
             for current_dep in all_deps {
                 if dep == current_dep.name.as_str() {
-                    let dep_manifest = core.run(io.dependency_manifest(pkg)).unwrap().unwrap();
+                    let dep_manifest = core.run(io.dependency_manifest(pkg)).unwrap();
+                    // Filter out dependencies without a manifest
+                    if dep_manifest.is_none() {
+                        continue;
+                    }
+                    let dep_manifest = dep_manifest.unwrap();
                     map.insert(
                         pkg_name.to_string(),
                         format!(

--- a/src/cmd/parents.rs
+++ b/src/cmd/parents.rs
@@ -48,16 +48,28 @@ pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
                     let dep_manifest = core.run(io.dependency_manifest(pkg)).unwrap();
                     // Filter out dependencies without a manifest
                     if dep_manifest.is_none() {
+                        map.insert(
+                            pkg_name.to_string(),
+                            "unknown, manifest unavailable".to_string(),
+                        );
                         continue;
                     }
                     let dep_manifest = dep_manifest.unwrap();
-                    map.insert(
-                        pkg_name.to_string(),
-                        format!(
-                            "{}",
-                            DependencyConstraint::from(&dep_manifest.dependencies[dep])
-                        ),
-                    );
+                    if dep_manifest.dependencies.contains_key(dep) {
+                        map.insert(
+                            pkg_name.to_string(),
+                            format!(
+                                "{}",
+                                DependencyConstraint::from(&dep_manifest.dependencies[dep])
+                            ),
+                        );
+                    } else {
+                        // Filter out dependencies with mismatching manifest
+                        map.insert(
+                            pkg_name.to_string(),
+                            "unknown, manifest mismatch".to_string(),
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
In case a dependency doesn't have a manifest, the parents command panicks as it cannot read the dependencies from the manifest. This fixes the issue, simply ignoring these dependencies.