### PR TITLE
Dependency names are lowercase to reduce ambiguity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Interpret all dependency names as lowercase to reduce ambiguity
 
 ## 0.24.0 - 2022-01-06
 ### Added

--- a/src/cmd/clone.rs
+++ b/src/cmd/clone.rs
@@ -34,7 +34,7 @@ pub fn new<'a, 'b>() -> App<'a, 'b> {
 
 /// Execute the `clone` subcommand.
 pub fn run(sess: &Session, path: &Path, matches: &ArgMatches) -> Result<()> {
-    let dep = matches.value_of("name").unwrap();
+    let dep = &matches.value_of("name").unwrap().to_lowercase();
     sess.dependency_with_name(dep)?;
 
     let path_mod = matches.value_of("path").unwrap_or_else(|| "working_dir"); // TODO make this option for config in the Bender.yml file?

--- a/src/cmd/parents.rs
+++ b/src/cmd/parents.rs
@@ -26,7 +26,7 @@ pub fn new<'a, 'b>() -> App<'a, 'b> {
 
 /// Execute the `parents` subcommand.
 pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
-    let dep = matches.value_of("name").unwrap();
+    let dep = &matches.value_of("name").unwrap().to_lowercase();
     sess.dependency_with_name(dep)?;
     let mut core = Core::new().unwrap();
     let io = SessionIo::new(&sess, core.handle());
@@ -39,7 +39,6 @@ pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
                 DependencyConstraint::from(&sess.manifest.dependencies[dep])
             );
             map.insert(sess.manifest.package.name.clone(), dep_str);
-            println!("Testing: {:?}", &sess.manifest.dependencies[dep]);
         }
         for (&pkg, deps) in sess.graph().iter() {
             let pkg_name = sess.dependency_name(pkg);

--- a/src/cmd/path.rs
+++ b/src/cmd/path.rs
@@ -30,7 +30,7 @@ pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
     let ids = matches
         .values_of("name")
         .unwrap()
-        .map(|n| Ok((n, sess.dependency_with_name(n)?)))
+        .map(|n| Ok((n, sess.dependency_with_name(&n.to_lowercase())?)))
         .collect::<Result<Vec<_>>>()?;
     debugln!("main: obtain checkouts {:?}", ids);
     let checkouts = core.run(future::join_all(

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -159,7 +159,7 @@ where
 {
     packages
         .into_iter()
-        .map(|t| t.as_ref().to_string())
+        .map(|t| t.as_ref().to_string().to_lowercase())
         .collect()
 }
 

--- a/src/cmd/sources.rs
+++ b/src/cmd/sources.rs
@@ -67,7 +67,7 @@ where
 {
     packages
         .into_iter()
-        .map(|t| t.as_ref().to_string())
+        .map(|t| t.as_ref().to_string().to_lowercase())
         .collect()
 }
 


### PR DESCRIPTION
Interpret all dependency names as lowercase to allow for custom capitalization, but no difference of the package (i.e. `fpnew` == `FPnew` or `axi` == `AXI`). May also increase compatibility for non-case-sensitive file systems.