### PR TITLE
Properly source dependency manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Fixed
 - Fix panic of `parents` command if a dependency does not have a manifest or if the manifest does not match the `Bender.lock` file.
+- Use correct manifest of checked out dependency in case folder already exists in `checkout_dir`.
 
 ## 0.24.0 - 2022-01-06
 ### Added

--- a/src/cmd/parents.rs
+++ b/src/cmd/parents.rs
@@ -48,10 +48,7 @@ pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
                     let dep_manifest = core.run(io.dependency_manifest(pkg)).unwrap();
                     // Filter out dependencies without a manifest
                     if dep_manifest.is_none() {
-                        map.insert(
-                            pkg_name.to_string(),
-                            "unknown, manifest unavailable".to_string(),
-                        );
+                        warnln!("{} is shown to include dependency, but manifest does not have this information.", pkg_name.to_string());
                         continue;
                     }
                     let dep_manifest = dep_manifest.unwrap();
@@ -65,10 +62,7 @@ pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
                         );
                     } else {
                         // Filter out dependencies with mismatching manifest
-                        map.insert(
-                            pkg_name.to_string(),
-                            "unknown, manifest mismatch".to_string(),
-                        );
+                        warnln!("{} is shown to include dependency, but manifest does not have this information.", pkg_name.to_string());
                     }
                 }
             }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -7,6 +7,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::fmt;
+use std::fs;
 use std::mem;
 
 use futures::future::join_all;
@@ -35,6 +36,8 @@ pub struct DependencyResolver<'ctx> {
     table: HashMap<&'ctx str, Dependency<'ctx>>,
     /// A cache of decisions made by the user during the resolution.
     decisions: HashMap<&'ctx str, usize>,
+    /// Checkout Directory overrides in case checkout_dir is defined and contains folders.
+    checked_out: HashMap<String, config::Dependency>,
 }
 
 impl<'ctx> DependencyResolver<'ctx> {
@@ -45,6 +48,7 @@ impl<'ctx> DependencyResolver<'ctx> {
             sess: sess,
             table: HashMap::new(),
             decisions: HashMap::new(),
+            checked_out: HashMap::new(),
         }
     }
 
@@ -61,6 +65,25 @@ impl<'ctx> DependencyResolver<'ctx> {
     pub fn resolve(mut self) -> Result<config::Locked> {
         let mut core = Core::new().unwrap();
         let io = SessionIo::new(self.sess, core.handle());
+
+        // Store path dependencies already in checkout_dir
+        if self.sess.manifest.workspace.checkout_dir.is_some() {
+            for dir in
+                fs::read_dir(self.sess.manifest.workspace.checkout_dir.clone().unwrap()).unwrap()
+            {
+                self.checked_out.insert(
+                    dir.as_ref()
+                        .unwrap()
+                        .path()
+                        .file_name()
+                        .unwrap()
+                        .to_str()
+                        .unwrap()
+                        .to_string(),
+                    config::Dependency::Path(dir.unwrap().path()),
+                );
+            }
+        }
 
         // Load the plugin dependencies.
         self.register_dependencies_in_manifest(
@@ -191,6 +214,7 @@ impl<'ctx> DependencyResolver<'ctx> {
             .map(|(name, dep)| {
                 let name = name.as_str();
                 let dep = self.sess.config.overrides.get(name).unwrap_or(dep);
+                let dep = self.checked_out.get(name).unwrap_or(dep);
                 (name, self.sess.load_dependency(name, dep, manifest))
             })
             .collect();
@@ -277,6 +301,9 @@ impl<'ctx> DependencyResolver<'ctx> {
                         pkg_name,
                         self.sess.config.overrides.get(name).unwrap_or(dep),
                     )
+                })
+                .map(|(name, pkg_name, dep)| {
+                    (name, pkg_name, self.checked_out.get(name).unwrap_or(dep))
                 });
             for (name, pkg_name, dep) in dep_iter {
                 let v = map.entry(name.as_str()).or_insert_with(|| Vec::new());


### PR DESCRIPTION
This PR properly links dependencies in a checkout_dir if present, emulating override path dependencies. This allows for a consistent dependency tree after `bender update` is run, as the local manifests are used to assign dependencies for each package, instead of a possibly out of date upstream version.