### PR TITLE
Fix install script error: main: line 276: [: : integer expression expected

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>Bender</title>
-		<meta http-equiv="refresh" content="0; URL=https://github.com/fabianschuiki/bender" />
+		<meta http-equiv="refresh" content="0; URL=https://github.com/pulp-platform/bender" />
 	</head>
 	<body>
 	</body>

--- a/init
+++ b/init
@@ -273,7 +273,7 @@ get_architecture() {
 get_distribution() {
     local _vendor=$(lsb_release -i | cut -f 2 | tr '[:upper:]' '[:lower:]')
     local _release=$(lsb_release -r | cut -f 2)
-    if [ "$_vendor" = "centos" -a "$(echo "$_release" | cut -d. -f3)" -lt 1708 ]; then
+    if [ "$_vendor" = "centos" ] && [ "$(echo "$_release" | cut -d. -f3)" -lt 1708 ]; then
         say "Warning: CentOS older than 7.4.1708 detected, falling back to the latter."
         _release="7.4.1708"
     fi


### PR DESCRIPTION
This PR fixes the following error message on `ubuntu 20.04`:
```
curl --proto '=https' https://pulp-platform.github.io/bender/init -sSf | /bin/bash
main: line 276: [: : integer expression expected
```
that arises when calling the install script:  `curl --proto '=https' https://pulp-platform.github.io/bender/init -sSf | /bin/sh`

Furthermore, I adjusted the url to link to the pulp-platform repo instead of Fabian Schuiki personal repo

