### PR TITLE
Git permissions

### DIFF
--- a/src/sess.rs
+++ b/src/sess.rs
@@ -524,6 +524,7 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
                                 "Please ensure your public ssh key is added to the git server."
                             );
                         }
+                        warnln!("Please ensure the url is correct and you have access to the repository.");
                         Error::chain(
                             format!("Failed to initialize git database in {:?}.", db_dir),
                             cause,
@@ -553,6 +554,7 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
                                 "Please ensure your public ssh key is added to the git server."
                             );
                         }
+                        warnln!("Please ensure the url is correct and you have access to the repository.");
                         Error::chain(
                             format!("Failed to update git database in {:?}.", db_dir),
                             cause,

--- a/src/sess.rs
+++ b/src/sess.rs
@@ -495,6 +495,7 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
         let name2 = String::from(name);
         let url = String::from(url);
         let url2 = url.clone();
+        let url3 = url.clone();
 
         // Either initialize the repository or update it if needed.
         if !db_dir.join("config").exists() {
@@ -518,6 +519,11 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
                     })
                     .and_then(move |_| git.fetch("origin"))
                     .map_err(move |cause| {
+                        if url3.contains("git@") {
+                            warnln!(
+                                "Please ensure your public ssh key is added to the git server."
+                            );
+                        }
                         Error::chain(
                             format!("Failed to initialize git database in {:?}.", db_dir),
                             cause,

--- a/src/sess.rs
+++ b/src/sess.rs
@@ -548,6 +548,11 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
                     })
                     .and_then(move |_| git.fetch("origin"))
                     .map_err(move |cause| {
+                        if url3.contains("git@") {
+                            warnln!(
+                                "Please ensure your public ssh key is added to the git server."
+                            );
+                        }
                         Error::chain(
                             format!("Failed to update git database in {:?}.", db_dir),
                             cause,


### PR DESCRIPTION
Add various warnings to provide hints for why a git dependency may be failing. Usually this error will relate to a bad git url, bad access permissions, or a missing ssh key on the git server. Other reasons are possible, but this should provide some hints to a new user.