### PR TITLE
Fix panic with checkout_dir if dir does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Use correct manifest of checked out dependency in case folder already exists in `checkout_dir`.
 - Fix vcs script argument to use `vhdlan-bin` for vhdlan binary
 - Fix incomplete dependency version update when refetching from remote
+- Fix panic when using `checkout_dir` if the directory does not yet exist
 
 ## 0.24.0 - 2022-01-06
 ### Added

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -69,18 +69,20 @@ impl<'ctx> DependencyResolver<'ctx> {
         // Store path dependencies already in checkout_dir
         match self.sess.manifest.workspace.checkout_dir.clone() {
             Some(checkout) => {
-                for dir in fs::read_dir(checkout).unwrap() {
-                    self.checked_out.insert(
-                        dir.as_ref()
-                            .unwrap()
-                            .path()
-                            .file_name()
-                            .unwrap()
-                            .to_str()
-                            .unwrap()
-                            .to_string(),
-                        config::Dependency::Path(dir.unwrap().path()),
-                    );
+                if checkout.exists() {
+                    for dir in fs::read_dir(checkout).unwrap() {
+                        self.checked_out.insert(
+                            dir.as_ref()
+                                .unwrap()
+                                .path()
+                                .file_name()
+                                .unwrap()
+                                .to_str()
+                                .unwrap()
+                                .to_string(),
+                            config::Dependency::Path(dir.unwrap().path()),
+                        );
+                    }
                 }
             }
             None => {}


### PR DESCRIPTION
When running `bender update`, the command may currently panic if the `checkout_dir` directory optionally specified in the top-level `Bender.yml` file does not yet exist