### PR TITLE
Fix incomplete dependency version update when refetching from remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Fix panic of `parents` command if a dependency does not have a manifest or if the manifest does not match the `Bender.lock` file.
 - Use correct manifest of checked out dependency in case folder already exists in `checkout_dir`.
 - Fix vcs script argument to use `vhdlan-bin` for vhdlan binary
+- Fix incomplete dependency version update when refetching from remote
 
 ## 0.24.0 - 2022-01-06
 ### Added

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -451,7 +451,7 @@ impl<'ctx> DependencyResolver<'ctx> {
         // debugln!("resolve: restricting `{}` to versions {:?}", name, indices);
 
         if indices.is_empty() {
-            core.run(io.dependency_versions(src.id, true))?;
+            src.versions = core.run(io.dependency_versions(src.id, true))?;
 
             let indices = match self.req_indices(name, con, src) {
                 Ok(o) => match o {


### PR DESCRIPTION
When releasing a new version of a dependency and updating the reference in a `Bender.yml` file, bender will not immediately find the correct reference when calling `bender update`, although it does fetch the dependency. Calling `bender update` again will fix this, but it should be done in the first step, without causing an error.

This improvement was introduced in v0.22.0 with b42ed72b9dac7b27b1da62c8649b09f558c7982f, but the implementation is incomplete. This change should properly update the dependency list.