### PR TITLE
Add checkout command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Add `checkout` command to fetch and checkout dependencies
+
 ### Fixed
 - Ensure consistency when manually chosing a version if there are conflicts.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,7 +55,8 @@ pub fn main() -> Result<()> {
         .subcommand(cmd::packages::new())
         .subcommand(cmd::sources::new())
         .subcommand(cmd::config::new())
-        .subcommand(cmd::script::new());
+        .subcommand(cmd::script::new())
+        .subcommand(cmd::checkout::new());
 
     // Add the `--debug` option in debug builds.
     let app = if cfg!(debug_assertions) {
@@ -229,6 +230,7 @@ pub fn main() -> Result<()> {
         ("sources", Some(matches)) => cmd::sources::run(&sess, matches),
         ("config", Some(matches)) => cmd::config::run(&sess, matches),
         ("script", Some(matches)) => cmd::script::run(&sess, matches),
+        ("checkout", Some(matches)) => cmd::checkout::run(&sess, matches),
         ("update", _) => Ok(()),
         (plugin, Some(matches)) => execute_plugin(&sess, plugin, matches.values_of_os("")),
         _ => Ok(()),

--- a/src/cmd/checkout.rs
+++ b/src/cmd/checkout.rs
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 ETH Zurich
+// Michael Rogenmoser <michaero@iis.ee.ethz.ch>
+
+//! The `checkout` subcommand.
+
+use clap::{App, ArgMatches, SubCommand};
+use tokio_core::reactor::Core;
+
+use crate::error::*;
+use crate::sess::{Session, SessionIo};
+
+/// Assemble the `checkout` subcommand.
+pub fn new<'a, 'b>() -> App<'a, 'b> {
+    SubCommand::with_name("checkout").about("Checkout all dependencies referenced in the Lock file")
+}
+
+/// Execute the `checkout` subcommand.
+pub fn run(sess: &Session, _matches: &ArgMatches) -> Result<()> {
+    let mut core = Core::new().unwrap();
+    let io = SessionIo::new(&sess, core.handle());
+    let _srcs = core.run(io.sources())?;
+
+    Ok(())
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -7,6 +7,7 @@
 
 #![deny(missing_docs)]
 
+pub mod checkout;
 pub mod clone;
 pub mod config;
 pub mod packages;

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,7 +21,7 @@ macro_rules! errorln {
 /// Print a warning.
 #[macro_export]
 macro_rules! warnln {
-    ($($arg:tt)*) => { diagnostic!($crate::error::Severity::Warning; $($arg)*); }
+    ($($arg:tt)*) => { diagnostic!($crate::error::Severity::Warning; $($arg)*) }
 }
 
 /// Print an informational note.
@@ -54,7 +54,7 @@ macro_rules! debugln {
 /// Emit a diagnostic message.
 macro_rules! diagnostic {
     ($severity:expr; $($arg:tt)*) => {
-        eprintln!("{} {}", $severity, format!($($arg)*));
+        eprintln!("{} {}", $severity, format!($($arg)*))
     }
 }
 


### PR DESCRIPTION
Add `checkout` command to fetch and checkout dependencies. This is automatically taken care of by any script generation/sources command, however some users prefer an explicit command.