### PR TITLE
Enforce version selection consistency (#85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Ensure consistency when manually chosing a version if there are conflicts.
 
 ## 0.25.1 - 2022-04-08
 ### Fixed


### PR DESCRIPTION
Save the DependencyConstraint instead of an ID to ensure the proper version remains consistent when selecting one manually.

This issue is quite difficult to reproduce, and may remain hidden as the behavior is not very consistent.