### PR TITLE
Update `Bender.lock` when running `bender clone`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## Unreleased
 ### Fixed
 - Ensure consistency when manually chosing a version if there are conflicts.
+- Update `Bender.lock` when running `bender clone`. Running `bender update` is no longer required afterwards.
 
 ## 0.25.1 - 2022-04-08
 ### Fixed

--- a/src/config.rs
+++ b/src/config.rs
@@ -731,7 +731,7 @@ pub struct Locked {
 /// A locked dependency.
 ///
 /// Encapsualtes the exact source and version of a dependency.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct LockedPackage {
     /// The revision hash of the dependency.
     pub revision: Option<String>,
@@ -744,7 +744,7 @@ pub struct LockedPackage {
 }
 
 /// A source description for a locked dependency.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub enum LockedSource {
     /// A path on the system.
     Path(PathBuf),


### PR DESCRIPTION
This removes the requirement to run `bender update` after cloning a dependency. Fixes #46.