### PR TITLE
Add formality support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+### Added
+- Added `formality` script.
+
 ### Changed
 - Update dependencies, with slight restructuring updating `clap` to v3.1, bumps minimum rust to 1.54
+- Removed `defines` from VHDL in `synopsys` script.
 
 ## 0.25.2 - 2022-04-13
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bender"
-version = "0.25.2"
+version = "0.25.2-dev"
 dependencies = [
  "atty",
  "blake2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bender"
-version = "0.25.2"
+version = "0.25.2-dev"
 authors = ["Fabian Schuiki <fschuiki@iis.ee.ethz.ch>", "Andreas Kurth <akurth@iis.ee.ethz.ch>", "Michael Rogenmoser <michael@rogenmoser.us>"]
 repository = "https://github.com/pulp-platform/bender"
 description = "A dependency management tool for hardware projects."


### PR DESCRIPTION
The formality script is slightly so different to the `dc_shell` syntax. This also removes the `define` option which has no meaning for VHDL files (and becomes an error in `formality`).