### PR TITLE
Fix path subdependencies in git dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Changed
 - Update `tokio` dependency, update to `futures=0.3`, rewrite for `async/await`. Bumps minimum rust to 1.57
 - Update `serde_yaml` dependency to `0.9`. Bumps minimum rust to 1.58
+- Partially checkout path dependencies in git dependencies
+- Add warnings if manifest file is not found for a dependency
 
 ## 0.25.3 - 2022-08-05
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "async-recursion"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cda8f4bcc10624c4e85bc66b3f452cca98cfa5ca002dc83a16aad2367641bea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -23,6 +34,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 name = "bender"
 version = "0.25.3"
 dependencies = [
+ "async-recursion",
  "atty",
  "blake2",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = "1"
 
 futures = "0.3"
 tokio = { version = "1.20", features = ["full"] }
+async-recursion = "1.0"
 
 clap = { version = "3.1", features = ["derive"] }
 semver = "1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ extern crate serde;
 extern crate serde_json;
 extern crate serde_yaml;
 
+extern crate async_recursion;
 extern crate futures;
 extern crate tokio;
 


### PR DESCRIPTION
- Partially checkout path dependencies in git dependencies
- Add warnings if manifest file is not found for a dependency
