### PR TITLE
Fix: Keep export_incdirs even when excluding deps

### DIFF
--- a/src/src.rs
+++ b/src/src.rs
@@ -172,8 +172,7 @@ impl<'ctx> SourceGroup<'ctx> {
                 .collect();
         }
 
-        let mut export_incdirs = self.export_incdirs.clone();
-        export_incdirs.retain(|k, _| packages.contains(k));
+        let export_incdirs = self.export_incdirs.clone();
         Some(
             SourceGroup {
                 package: self.package,


### PR DESCRIPTION
Include directories may be needed to properly parse files, so this PR enforces keeping `export_incdirs` for dependencies when excluding dependencies, e.g. with `-n` or `-e` flags. 