### PR TITLE
import: Streamline init of external dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Streamline `import` command for initializing a repository
 
 ## 0.26.1 - 2022-08-29
 ### Fixed

--- a/src/cmd/import.rs
+++ b/src/cmd/import.rs
@@ -97,6 +97,9 @@ pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
             let git = Git::new(tmp_path, &sess.config.git);
 
             for link in vendor_package.mapping.clone() {
+                if !link.to.clone().is_dir() {
+                    Err(Error::new(format!("Could not find target directory {:?}. Please initialize the external dependency with \"bender import --refetch\".", link.to.clone())))?;
+                }
                 // Apply patches
                 if !matches.is_present("no_patch") {
                     if let Some(patch) = link.patch_dir.clone() {
@@ -212,7 +215,8 @@ pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
                                 patch_path.to_str().unwrap().to_lowercase()
                             });
 
-                            let new_patch = if matches.is_present("no_patch") {
+                            let new_patch = if matches.is_present("no_patch") || patches.is_empty()
+                            {
                                 // Remove all old patches
                                 for patch_file in patches {
                                     std::fs::remove_file(patch_file)?;


### PR DESCRIPTION
Streamline the initialization of an external dependency. In particular:

- Catch missing target dir
- Create initial patch if none exist
