### PR TITLE
init: Use bash

### DIFF
--- a/init
+++ b/init
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/bash
 
 # Copyright (c) 2019 ETH Zurich
 # SPDX-License-Identifier: Apache-2.0 OR MIT


### PR DESCRIPTION
This script is not fully POSIX-compliant (see shellcheck complaints). Easiest fix is to just use bash.