### PR TITLE
import: Restructure and extend functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ If the `--plain` argument is passed, this command will *not* prompt for a commit
 #### Example workflow
 
 Let's assume we would like to vendor a dependency `my_ip` into a project `monorepo`.
-A simple configuration ind `Bender.yml` could look as follows (see the `Bender.yml` description above for more information on this):
+A simple configuration in a `Bender.yml` could look as follows (see the `Bender.yml` description above for more information on this):
 
 ```yaml
 vendor_package:
@@ -501,7 +501,7 @@ We can print these changes with the command `bender vendor diff`.
 Now, we would like to generate a patch with the changes in `deps/my_ip/a` (but not those in `deps/my_ip/b`).
 We stage the desired changes using `git add deps/my_ip/a` (of course, you can also just stage parts of a file using `git add --patch`).
 The command `bender vendor patch` will now ask for a commit message that will be associated with this patch.
-Then, it will place a patch that contains our changes in `deps/my_ip/a` into `deps/patches/my_ip/0001-commit-message.patch`
+Then, it will place a patch that contains our changes in `deps/my_ip/a` into `deps/patches/my_ip/0001-commit-message.patch` (the number will increment if a numbered patch is already present).
 
 We can easily create a corresponding commit in the monorepo.
 `deps/my_ip/a` is still staged from the previous step.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,7 +55,7 @@ pub fn main() -> Result<()> {
         .subcommand(cmd::config::new())
         .subcommand(cmd::script::new())
         .subcommand(cmd::checkout::new())
-        .subcommand(cmd::import::new());
+        .subcommand(cmd::vendor::new());
 
     // Add the `--debug` option in debug builds.
     let app = if cfg!(debug_assertions) {
@@ -235,7 +235,7 @@ pub fn main() -> Result<()> {
         Some(("script", matches)) => cmd::script::run(&sess, matches),
         Some(("checkout", matches)) => cmd::checkout::run(&sess, matches),
         Some(("update", _)) => Ok(()),
-        Some(("vendor", matches)) => cmd::import::run(&sess, matches),
+        Some(("vendor", matches)) => cmd::vendor::run(&sess, matches),
         Some((plugin, matches)) => execute_plugin(&sess, plugin, matches.values_of_os("")),
         _ => Ok(()),
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -235,7 +235,7 @@ pub fn main() -> Result<()> {
         Some(("script", matches)) => cmd::script::run(&sess, matches),
         Some(("checkout", matches)) => cmd::checkout::run(&sess, matches),
         Some(("update", _)) => Ok(()),
-        Some(("import", matches)) => cmd::import::run(&sess, matches),
+        Some(("vendor", matches)) => cmd::import::run(&sess, matches),
         Some((plugin, matches)) => execute_plugin(&sess, plugin, matches.values_of_os("")),
         _ => Ok(()),
     }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -10,9 +10,9 @@
 pub mod checkout;
 pub mod clone;
 pub mod config;
-pub mod vendor;
 pub mod packages;
 pub mod parents;
 pub mod path;
 pub mod script;
 pub mod sources;
+pub mod vendor;

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -10,7 +10,7 @@
 pub mod checkout;
 pub mod clone;
 pub mod config;
-pub mod import;
+pub mod vendor;
 pub mod packages;
 pub mod parents;
 pub mod path;

--- a/src/cmd/vendor.rs
+++ b/src/cmd/vendor.rs
@@ -248,11 +248,7 @@ pub fn init(
     }
 
     // Copy src to dst recursively.
-    match &patch_link
-        .from_prefix
-        .prefix_paths(dep_path)
-        .is_dir()
-    {
+    match &patch_link.from_prefix.prefix_paths(dep_path).is_dir() {
         true => copy_recursively(
             &link_from,
             &link_to,

--- a/src/cmd/vendor.rs
+++ b/src/cmd/vendor.rs
@@ -579,6 +579,12 @@ pub fn copy_recursively(
                 includes,
                 ignore,
             )?;
+        } else if filetype.is_symlink() {
+            let orig = std::fs::read_link(entry.path());
+            std::os::unix::fs::symlink(
+                orig.unwrap(),
+                destination.as_ref().join(entry.file_name()),
+            )?;
         } else {
             std::fs::copy(entry.path(), destination.as_ref().join(entry.file_name()))?;
         }

--- a/src/cmd/vendor.rs
+++ b/src/cmd/vendor.rs
@@ -303,7 +303,7 @@ pub fn apply_patches(
                         let current_patch_target = if !patch_link
                             .from_prefix
                             .clone()
-                            .prefix_paths(git.path.clone())
+                            .prefix_paths(git.path)
                             .is_file()
                         {
                             patch_link.from_prefix.as_path()

--- a/src/cmd/vendor.rs
+++ b/src/cmd/vendor.rs
@@ -56,7 +56,9 @@ pub fn new<'a>() -> Command<'a> {
             )
             .arg(
                 Arg::new("message")
+                .long("message")
                 .short('m')
+                .takes_value(true)
                 .help("The message to be associated with the format-patch."),
             )
         )

--- a/src/cmd/vendor.rs
+++ b/src/cmd/vendor.rs
@@ -300,9 +300,21 @@ pub fn apply_patches(
                 })
                 .and_then(|_| {
                     git.spawn_with(|c| {
+                        let current_patch_target = if !patch_link
+                            .from_prefix
+                            .clone()
+                            .prefix_paths(git.path.clone())
+                            .is_file()
+                        {
+                            patch_link.from_prefix.as_path()
+                        } else {
+                            patch_link.from_prefix.parent().unwrap()
+                        }
+                        .to_str()
+                        .unwrap();
                         c.arg("apply")
                             .arg("--directory")
-                            .arg(patch_link.from_prefix.clone().to_str().unwrap())
+                            .arg(current_patch_target)
                             .arg("-p1")
                             .arg(&patch)
                     })

--- a/src/cmd/vendor.rs
+++ b/src/cmd/vendor.rs
@@ -455,7 +455,7 @@ pub fn gen_plain_patch(diff: String, patch_dir: impl AsRef<Path>, no_patch: bool
             for patch_file in patches {
                 std::fs::remove_file(patch_file)?;
             }
-            "0001-bender-import.patch".to_string()
+            "0001-bender-vendor.patch".to_string()
         } else {
             // Get all patch leading numeric keys (0001, ...) and generate new name
             let leading_numbers = patches
@@ -477,7 +477,7 @@ pub fn gen_plain_patch(diff: String, patch_dir: impl AsRef<Path>, no_patch: bool
                 .map(|s| s.parse::<i32>().unwrap())
                 .max()
                 .unwrap();
-            format!("{:04}-bender-import.patch", max_number + 1)
+            format!("{:04}-bender-vendor.patch", max_number + 1)
         };
 
         // write patch

--- a/src/cmd/vendor.rs
+++ b/src/cmd/vendor.rs
@@ -169,12 +169,7 @@ pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
                         .clone()
                         .to_prefix
                         .prefix_paths(&vendor_package.target_dir);
-                    if target_path.try_exists().map_err(|cause| {
-                        Error::chain(
-                            format!("Failed to check if {:?} already exists.", target_path),
-                            cause,
-                        )
-                    })? {
+                    if target_path.exists() {
                         if target_path.is_dir() {
                             std::fs::remove_dir_all(target_path.clone())
                         } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -776,7 +776,7 @@ impl PrefixPaths for VendorPackage {
         let patch_root = self.patch_dir.prefix_paths(prefix);
         VendorPackage {
             name: self.name,
-            target_dir: self.target_dir,
+            target_dir: self.target_dir.prefix_paths(prefix),
             upstream: self.upstream,
             mapping: self
                 .mapping

--- a/src/config.rs
+++ b/src/config.rs
@@ -843,9 +843,13 @@ impl Validate for PartialVendorPackage {
                 Some(include_from_upstream) => include_from_upstream,
                 None => vec![String::from("**")],
             },
-            exclude_from_upstream: match self.exclude_from_upstream {
-                Some(exclude_from_upstream) => exclude_from_upstream,
-                None => Vec::new(),
+            exclude_from_upstream: {
+                let mut excl = match self.exclude_from_upstream {
+                    Some(exclude_from_upstream) => exclude_from_upstream,
+                    None => Vec::new(),
+                };
+                excl.push(String::from(".git"));
+                excl
             },
         })
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -784,7 +784,11 @@ impl PrefixPaths for VendorPackage {
                 .map(|ftl| FromToLink {
                     from: ftl.from,
                     to: ftl.to,
-                    patch_dir: ftl.patch_dir.map(|dir| dir.prefix_paths(&patch_root.clone().expect("A mapping has a local patch_dir, but no global patch_dir is defined."))),
+                    patch_dir: ftl.patch_dir.map(|dir| {
+                        dir.prefix_paths(&patch_root.clone().expect(
+                            "A mapping has a local patch_dir, but no global patch_dir is defined.",
+                        ))
+                    }),
                 })
                 .collect(),
             patch_dir: patch_root,
@@ -839,7 +843,7 @@ impl Validate for PartialVendorPackage {
                 None => Vec::new(),
             },
             patch_dir: self.patch_dir,
-            include_from_upstream: match self.include_from_upstream{
+            include_from_upstream: match self.include_from_upstream {
                 Some(include_from_upstream) => include_from_upstream,
                 None => vec![String::from("**")],
             },

--- a/src/git.rs
+++ b/src/git.rs
@@ -164,7 +164,7 @@ impl<'git, 'ctx> Git<'ctx> {
     /// Commit the staged changes.
     ///
     /// If message is None, this starts an interactive commit session.
-    pub async fn commit(self, message: Option<&str>) -> Result<()> {
+    pub async fn commit(self, message: Option<&String>) -> Result<()> {
         match message {
             Some(msg) => self
                 .spawn_with(|c| {

--- a/src/git.rs
+++ b/src/git.rs
@@ -36,9 +36,9 @@ impl<'git, 'ctx> Git<'ctx> {
     /// The command will have the form `git <subcommand>` and be pre-configured
     /// to operate in the repository's path.
     pub fn command(self, subcommand: &str) -> Command {
-        let mut cmd = Command::new(&self.git);
+        let mut cmd = Command::new(self.git);
         cmd.arg(subcommand);
-        cmd.current_dir(&self.path);
+        cmd.current_dir(self.path);
         cmd
     }
 
@@ -109,8 +109,8 @@ impl<'git, 'ctx> Git<'ctx> {
     where
         F: FnOnce(&mut Command) -> &mut Command,
     {
-        let mut cmd = Command::new(&self.git);
-        cmd.current_dir(&self.path);
+        let mut cmd = Command::new(self.git);
+        cmd.current_dir(self.path);
         f(&mut cmd);
         self.spawn(cmd, true).await
     }
@@ -123,8 +123,8 @@ impl<'git, 'ctx> Git<'ctx> {
     where
         F: FnOnce(&mut Command) -> &mut Command,
     {
-        let mut cmd = Command::new(&self.git);
-        cmd.current_dir(&self.path);
+        let mut cmd = Command::new(self.git);
+        cmd.current_dir(self.path);
         f(&mut cmd);
         self.spawn(cmd, false).await
     }
@@ -137,8 +137,8 @@ impl<'git, 'ctx> Git<'ctx> {
     where
         F: FnOnce(&mut Command) -> &mut Command,
     {
-        let mut cmd = Command::new(&self.git);
-        cmd.current_dir(&self.path);
+        let mut cmd = Command::new(self.git);
+        cmd.current_dir(self.path);
         f(&mut cmd);
         cmd.spawn()?.wait().await?;
         Ok(())

--- a/src/git.rs
+++ b/src/git.rs
@@ -156,7 +156,9 @@ impl<'git, 'ctx> Git<'ctx> {
 
     /// Stage all local changes.
     pub async fn add_all(self) -> Result<()> {
-        self.spawn_with(|c| c.arg("add").arg("--all")).await.map(|_| ())
+        self.spawn_with(|c| c.arg("add").arg("--all"))
+            .await
+            .map(|_| ())
     }
 
     /// Commit the staged changes.
@@ -164,23 +166,21 @@ impl<'git, 'ctx> Git<'ctx> {
     /// If message is None, this starts an interactive commit session.
     pub async fn commit(self, message: Option<&str>) -> Result<()> {
         match message {
-            Some(msg) => {
-                self.spawn_with(|c| {
-                   c.arg("-c")
-                    .arg("commit.gpgsign=false")
-                    .arg("commit")
-                    .arg("-m")
-                    .arg(msg)
-                }).await.map(|_| ())
-            },
-
-            None => {
-                self.spawn_interactive_with(|c| {
+            Some(msg) => self
+                .spawn_with(|c| {
                     c.arg("-c")
-                    .arg("commit.gpgsign=false")
-                    .arg("commit")
-                }).await.map(|_| ())
-            },
+                        .arg("commit.gpgsign=false")
+                        .arg("commit")
+                        .arg("-m")
+                        .arg(msg)
+                })
+                .await
+                .map(|_| ()),
+
+            None => self
+                .spawn_interactive_with(|c| c.arg("-c").arg("commit.gpgsign=false").arg("commit"))
+                .await
+                .map(|_| ()),
         }
     }
 


### PR DESCRIPTION
Refactor and extend the `import` subcommand. The most significant changes:
- Rename the subcommand to `vendor`.
- Use sub-sub commands (`init`, `diff`, `patch`) for main functionality. One sub-sub command has to be provided (otherwise the help message will appear)
- Emit format-patches per default for more control over patch contents and improved trackability and upstreamability. The old behaviour (plain diff) can be achieved using the `--plain` flag.
- Make mappings optional (actually they should be used with caution). If no mappings are provided, the directory structure of the dependency will be kept and copied to `target_dir`.
- Add an optional `include_from_upstream` field to specify patterns that need to match the items of the dependency that are to be copied.

More information on the usage in README.md
