### PR TITLE
Fix overrides dependency name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Fixed
 - Use `IndexMap` and `IndexSet` instead of the `std Hash*` equivalents to preserve ordering
 - Change GNU release to be built to a more compatible binary (manylinux container).
+- Parse override dependencies in lowercase to align to change in 0.25.0
 
 ## 0.27.1 - 2023-01-25
 ### Fixed

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -392,8 +392,17 @@ fn load_config(from: &Path) -> Result<Config> {
     out = out.merge(default_cfg);
 
     // Validate the configuration.
-    out.validate()
-        .map_err(|cause| Error::chain("Invalid configuration:", cause))
+    let mut out = out
+        .validate()
+        .map_err(|cause| Error::chain("Invalid configuration:", cause))?;
+
+    out.overrides = out
+        .overrides
+        .into_iter()
+        .map(|(k, v)| (k.to_lowercase(), v))
+        .collect();
+
+    Ok(out)
 }
 
 /// Load a configuration file if it exists.


### PR DESCRIPTION
Parse override dependencies in lowercase to align to change in 0.25.0