### PR TITLE
path: Skip checkout if possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Unreleased
 ### Added
-- Add `--no-checkout` flag to `path` command to avoid checkout if not needed.
+- Add `--checkout` flag to `path` command to force checkout if needed.
+- Add `--no-checkout` flag to `update` command to prevent checkout after update if not needed.
+
+### Changed
+- `path` and local links: Skip checkout if package path already exists (can be overruled by `--checkout` flag)
+- `update`: Default to automatically perform checkout after update (can be overruled by `--no-checkout` flag)
 
 ### Fixed
 - Improve ReadMe and Warning information for `vendor` upstream linking.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Add `--no-checkout` flag to `path` command to avoid checkout if not needed.
+
 ### Fixed
 - Improve ReadMe and Warning information for `vendor` upstream linking.
 - Ensure `workspace.package_links` symlinks are properly updated when executing the `clone` command.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -173,6 +173,14 @@ pub fn main() -> Result<()> {
     sess.load_locked(&locked)?;
 
     // Ensure the locally linked packages are up-to-date.
+    if matches.subcommand_name() == Some("update")
+        || !sess
+            .manifest
+            .workspace
+            .package_links
+            .clone()
+            .into_iter()
+            .all(|(path, _)| path.exists())
     {
         let rt = Runtime::new()?;
         let io = SessionIo::new(&sess);
@@ -244,6 +252,8 @@ pub fn main() -> Result<()> {
                 }
             }
         }
+    } else {
+        debugln!("main: All links up-to-date, skipping re-linking");
     }
 
     // Dispatch the different subcommands.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,14 +49,23 @@ pub fn main() -> Result<()> {
                 .help("Disables fetching of remotes (e.g. for air-gapped computers)"),
         )
         .subcommand(
-            Command::new("update").about("Update the dependencies").arg(
-                Arg::new("fetch")
-                    .short('f')
-                    .long("fetch")
-                    .num_args(0)
-                    .action(ArgAction::SetTrue)
-                    .help("forces fetch of git dependencies"),
-            ),
+            Command::new("update")
+                .about("Update the dependencies")
+                .arg(
+                    Arg::new("fetch")
+                        .short('f')
+                        .long("fetch")
+                        .num_args(0)
+                        .action(ArgAction::SetTrue)
+                        .help("forces fetch of git dependencies"),
+                )
+                .arg(
+                    Arg::new("no-checkout")
+                        .long("no-checkout")
+                        .num_args(0)
+                        .action(ArgAction::SetTrue)
+                        .help("Disables checkout of dependencies"),
+                ),
         )
         .subcommand(cmd::path::new())
         .subcommand(cmd::parents::new())
@@ -263,7 +272,13 @@ pub fn main() -> Result<()> {
         Some(("config", matches)) => cmd::config::run(&sess, matches),
         Some(("script", matches)) => cmd::script::run(&sess, matches),
         Some(("checkout", matches)) => cmd::checkout::run(&sess, matches),
-        Some(("update", _)) => Ok(()),
+        Some(("update", _)) => {
+            if matches.get_flag("no-checkout") {
+                Ok(())
+            } else {
+                cmd::checkout::run(&sess, &matches)
+            }
+        }
         Some(("vendor", matches)) => cmd::vendor::run(&sess, matches),
         Some(("fusesoc", matches)) => cmd::fusesoc::run(&sess, matches),
         Some((plugin, matches)) => execute_plugin(&sess, plugin, matches.get_many::<OsString>("")),

--- a/src/cmd/path.rs
+++ b/src/cmd/path.rs
@@ -3,7 +3,7 @@
 
 //! The `path` subcommand.
 
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use futures::future::join_all;
 use tokio::runtime::Runtime;
 
@@ -20,31 +20,50 @@ pub fn new() -> Command {
                 .required(true)
                 .help("Package names to get the path for"),
         )
+        .arg(
+            Arg::new("no-checkout")
+                .long("no-checkout")
+                .num_args(0)
+                .action(ArgAction::SetTrue)
+                .help("Prevents check out of dependency."),
+        )
 }
 
 /// Execute the `path` subcommand.
 pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
-    let rt = Runtime::new()?;
-    let io = SessionIo::new(sess);
-
     let ids = matches
         .get_many::<String>("name")
         .unwrap()
         .map(|n| Ok((n, sess.dependency_with_name(&n.to_lowercase())?)))
         .collect::<Result<Vec<_>>>()?;
-    debugln!("main: obtain checkouts {:?}", ids);
-    let checkouts = rt
-        .block_on(join_all(
-            ids.iter()
-                .map(|&(_, id)| io.checkout(id))
-                .collect::<Vec<_>>(),
-        ))
-        .into_iter()
-        .collect::<Result<Vec<_>>>()?;
-    debugln!("main: checkouts {:#?}", checkouts);
-    for c in checkouts {
-        if let Some(s) = c.to_str() {
-            println!("{}", s);
+
+    let io = SessionIo::new(sess);
+    if !matches.get_flag("no-checkout") {
+        debugln!("main: obtain checkouts {:?}", ids);
+        let rt = Runtime::new()?;
+        let checkouts = rt
+            .block_on(join_all(
+                ids.iter()
+                    .map(|&(_, id)| io.checkout(id))
+                    .collect::<Vec<_>>(),
+            ))
+            .into_iter()
+            .collect::<Result<Vec<_>>>()?;
+        debugln!("main: checkouts {:#?}", checkouts);
+        for c in checkouts {
+            if let Some(s) = c.to_str() {
+                println!("{}", s);
+            }
+        }
+    } else {
+        let paths = ids
+            .iter()
+            .map(|&(_, id)| io.get_package_path(id))
+            .collect::<Vec<_>>();
+        for c in paths {
+            if let Some(s) = c.to_str() {
+                println!("{}", s);
+            }
         }
     }
     Ok(())


### PR DESCRIPTION
Reduce bender's footprint by skipping checkout of a package if the package path already exists and
- `path` is executed (can be overruled by new `--checkout` flag), or
- for locally linked packages if any command except for `update` is executed.

To prevent `bender path` from returning stale paths, a checkout is now performed automatically after executing `update`. This can be prevented by passing the new `--no-checkout` flag to `update`.