### PR TITLE
README.md: Correct description of configuration merging logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ It will also look recursively upwards from the current working directory for the
 - `.bender.yml`
 - `Bender.local`
 
-The contents of these files are merged as they are encountered, such that a configuration in `foo/bar/.bender.yml` will overwrite a configuration in `foo/.bender.yml`.
+The contents of these files are merged as they are encountered, such that a configuration in `foo/.bender.yml` will overwrite a configuration in `foo/bar/.bender.yml`.
 
 The configuration file generally looks as follows:
 


### PR DESCRIPTION
As can be observed in the following lines, the filesystem is traversed upwards to search for configuration files. Configuration files which are reached later override previous configuration files.
https://github.com/pulp-platform/bender/blob/25c518464b6a0c098e815c84f055e8fc2a4829f1/src/cli.rs#L369-L374
https://github.com/pulp-platform/bender/blob/25c518464b6a0c098e815c84f055e8fc2a4829f1/src/config.rs#L702-L714

This PR amends the description in `README.md`.