### PR TITLE
Add `clean` command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -82,7 +82,8 @@ pub fn main() -> Result<()> {
         .subcommand(cmd::checkout::new())
         .subcommand(cmd::vendor::new())
         .subcommand(cmd::fusesoc::new())
-        .subcommand(cmd::init::new());
+        .subcommand(cmd::init::new())
+        .subcommand(cmd::clean::new());
 
     // Add the `--debug` option in debug builds.
     let app = if cfg!(debug_assertions) {
@@ -131,6 +132,10 @@ pub fn main() -> Result<()> {
             .map_err(|cause| Error::chain("Cannot find root directory of package.", cause))?,
     };
     debugln!("main: root dir {:?}", root_dir);
+
+    if let Some(("clean", matches)) = matches.subcommand() {
+        return cmd::clean::run(&root_dir, matches);
+    }
 
     // Parse the manifest file of the package.
     let manifest_path = root_dir.join("Bender.yml");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -133,10 +133,6 @@ pub fn main() -> Result<()> {
     };
     debugln!("main: root dir {:?}", root_dir);
 
-    if let Some(("clean", matches)) = matches.subcommand() {
-        return cmd::clean::run(&root_dir, matches);
-    }
-
     // Parse the manifest file of the package.
     let manifest_path = root_dir.join("Bender.yml");
     let manifest = read_manifest(&manifest_path)?;
@@ -156,6 +152,11 @@ pub fn main() -> Result<()> {
         matches.get_flag("local"),
         force_fetch,
     );
+
+    // Execute the `clean` subcommand if requested.
+    if let Some(("clean", intern_matches)) = matches.subcommand() {
+        return cmd::clean::run(&sess, intern_matches.get_flag("force"));
+    }
 
     // Read the existing lockfile.
     let lock_path = root_dir.join("Bender.lock");

--- a/src/cmd/clean.rs
+++ b/src/cmd/clean.rs
@@ -1,0 +1,26 @@
+// Copyright (c) 2024 ETH Zurich
+// Tim Fischer <fischeti@iis.ee.ethz.ch>
+
+//! The `clean` subcommand.
+
+use std::path::PathBuf;
+
+use clap::{ArgMatches, Command};
+
+use crate::error::*;
+
+/// Assemble the `clean` subcommand.
+pub fn new() -> Command {
+  Command::new("clean").about("Clean the bender dependencies and the Lock file")
+}
+
+/// Execute the `clean` subcommand.
+pub fn run(root_dir: &PathBuf, _matches: &ArgMatches) -> Result<()> {
+  if root_dir.join("Bender.lock").exists() {
+    std::fs::remove_file(root_dir.join("Bender.lock"))?;
+  }
+  if root_dir.join(".bender").exists() {
+    std::fs::remove_dir_all(root_dir.join(".bender"))?;
+  }
+  Ok(())
+}

--- a/src/cmd/clean.rs
+++ b/src/cmd/clean.rs
@@ -3,24 +3,51 @@
 
 //! The `clean` subcommand.
 
-use std::path::PathBuf;
+use clap::{Arg, ArgAction, Command};
 
-use clap::{ArgMatches, Command};
-
+use crate::config::Dependency;
 use crate::error::*;
+use crate::sess::Session;
 
 /// Assemble the `clean` subcommand.
 pub fn new() -> Command {
-  Command::new("clean").about("Clean the bender dependencies and the Lock file")
+    Command::new("clean")
+        .about("Clean the bender dependencies and the Lock file")
+        .arg(
+            Arg::new("force")
+                .short('f')
+                .long("force")
+                .help("Force clean also the overrides specified in `Bender.local` files")
+                .action(ArgAction::SetTrue),
+        )
 }
 
 /// Execute the `clean` subcommand.
-pub fn run(root_dir: &PathBuf, _matches: &ArgMatches) -> Result<()> {
-  if root_dir.join("Bender.lock").exists() {
-    std::fs::remove_file(root_dir.join("Bender.lock"))?;
-  }
-  if root_dir.join(".bender").exists() {
-    std::fs::remove_dir_all(root_dir.join(".bender"))?;
-  }
-  Ok(())
+pub fn run(sess: &Session, force_clean: bool) -> Result<()> {
+    // Remove the database i.e. the `.bender` directory
+    if sess.config.database.exists() {
+        std::fs::remove_dir_all(&sess.config.database)?;
+    }
+
+    // Remove the lock file
+    if sess.root.join("Bender.lock").exists() {
+        std::fs::remove_file(sess.root.join("Bender.lock"))?;
+    }
+
+    // Dependency overrides that are paths are not removed by default,
+    // since they might contain uncommitted changes. The user is warned
+    // about this and can force the removal with the `--force` flag.
+    for (name, dep) in sess.config.overrides.iter() {
+        match (dep, force_clean) {
+            (Dependency::Path(_), false) => {
+                warnln!("Override for {} is a path, will not be removed", name)
+            }
+            (Dependency::Path(path), true) => {
+                debugln!("Removing override for {} at {}", name, path.display());
+                std::fs::remove_dir_all(path)?;
+            }
+            _ => (),
+        }
+    }
+    Ok(())
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -8,6 +8,7 @@
 #![deny(missing_docs)]
 
 pub mod checkout;
+pub mod clean;
 pub mod clone;
 pub mod config;
 pub mod fusesoc;


### PR DESCRIPTION
## Add `clean` command

This PR adds a `clean` command which can be used to remove all artifacts created by bender to start over in a "clean" state.

The functionality is still up to discussion. The current implementation removes the the following artifacts:
* The dependency database (i.e. the `.bender` directory by default)
* The `Bender.lock` file in the root directory

It does **not** remove the following artifacts:
* All path dependencies that are specified as overrides e.g. by the `Bender.local`. The reasoning behind is that these could originate from `bender clone` to work locally on the dependency for simplicity. Removing this might also remove uncommited changes to the dependency. The user is instead warned, and can still force the removal with the `force` flag.

### TODO:
- [ ] Update README
- [ ] Update CHANGELOG