### PR TITLE
Add error prop to generated vcs compile script

### DIFF
--- a/src/script_fmt/vcs_sh.tera
+++ b/src/script_fmt/vcs_sh.tera
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # {{ HEADER_AUTOGEN }}
-
-# Set propagation of error to exit on first error
+{% if abort_on_error %}# Set propagation of error to exit on first error
 set -e
+{% endif %}
 ROOT="{{ root }}"
 {% if compilation_mode == 'separate' %}{% for group in srcs %}
 {% if group.file_type == 'verilog' %}{{ vlogan_bin }} -sverilog \

--- a/src/script_fmt/vcs_sh.tera
+++ b/src/script_fmt/vcs_sh.tera
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 # {{ HEADER_AUTOGEN }}
+
+# Set propagation of error to exit on first error
+set -e
 ROOT="{{ root }}"
 {% if compilation_mode == 'separate' %}{% for group in srcs %}
 {% if group.file_type == 'verilog' %}{{ vlogan_bin }} -sverilog \


### PR DESCRIPTION
Change the VCS compile script template to start with a 
```set -e```
to ensure error propagation to fix #163.