### PR TITLE
Fix Error: Latest release not available for platform 'x86_64-linux-gnu-ubuntu24.04'!

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,7 @@ jobs:
           - ubuntu:18.04
           - ubuntu:20.04
           - ubuntu:22.04
+          - ubuntu:24.04
           - fedora:37
           - fedora:38
           - fedora:39


### PR DESCRIPTION
As mentioned in #175 , the bender doesnt seem to work with OS Ubuntu 24.04 LTS, this pull request includes changes in `.github/workflows/release.yaml` to include build for OS `Ubuntu 24.04`.
The build workflow seems to fail on forked repository but that is because of broken link to the deployment page. It should not be an issue for the original repository.

Please consider admit the pull request into a side branch for validation.