### PR TITLE
README.md: Update `tera` link and `script flist` command description

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ The `bender config` command prints the currently active configuration as JSON to
 
 ### `script` --- Generate tool-specific scripts
 
-The `bender script <format>` command can generate scripts to feed the source code of a package and its dependencies into a vendor tool. These scripts are rendered using internally stored templates with the [tera](https://tera.netlify.app/) crate, but custom templates can also be used.
+The `bender script <format>` command can generate scripts to feed the source code of a package and its dependencies into a vendor tool. These scripts are rendered using internally stored templates with the [tera](https://keats.github.io/tera/docs/) crate, but custom templates can also be used.
 
 Supported formats:
 
@@ -429,8 +429,8 @@ Supported formats:
 - `vivado`: A Tcl file addition script for Xilinx Vivado.
 - `vivado-sim`: Same as `vivado`, but specifically for simulation targets.
 - `precision`: A Tcl compilation script for Mentor Precision.
-- `template`: A custom [tera](https://tera.netlify.app/) template, provided using the `--template` flag.
-- `template_json`: The json struct used to render the [tera](https://tera.netlify.app/) template.
+- `template`: A custom [tera](https://keats.github.io/tera/docs/) template, provided using the `--template` flag.
+- `template_json`: The json struct used to render the [tera](https://keats.github.io/tera/docs/) template.
 
 Furthermore, similar flags to the `sources` command exist.
 

--- a/README.md
+++ b/README.md
@@ -417,7 +417,8 @@ The `bender script <format>` command can generate scripts to feed the source cod
 
 Supported formats:
 
-- `flist`: A flat file list amenable to be directly inlined into the invocation command of a tool, e.g. `verilate $(bender script flist)`.
+- `flist`: A flat whitespace-separated file list.
+- `flist-plus`: A flat file list amenable to be directly inlined into the invocation command of a tool, e.g. `verilate $(bender script flist)`.
 - `vsim`: A Tcl compilation script for Mentor ModelSim/QuestaSim.
 - `vcs`:  A Tcl compilation script for VCS.
 - `verilator`: Command line arguments for Verilator.


### PR DESCRIPTION
This PR introduces the following changes to the README:
- Update the `flist` and add the `flist-plus` command descriptions (see https://github.com/pulp-platform/bender/issues/177)
- Update the link to the Tera crate documentation which seems to not live anymore at the previously linked location