### PR TITLE
Fix mapping limitation in vendor

### DIFF
--- a/src/cmd/vendor.rs
+++ b/src/cmd/vendor.rs
@@ -323,7 +323,7 @@ pub fn init(
 
     // Check if includes exist
     for path in vendor_package.include_from_upstream.clone() {
-        if !PathBuf::from(extend_paths(&[path.clone()], dep_path)?[0].clone()).exists() {
+        if !PathBuf::from(extend_paths(&[path.clone()], dep_path, true)?[0].clone()).exists() {
             warnln!("{} not found in upstream, continuing.", path);
         }
     }
@@ -333,7 +333,7 @@ pub fn init(
         true => copy_recursively(
             &link_from,
             &link_to,
-            &extend_paths(&vendor_package.include_from_upstream, dep_path)?,
+            &extend_paths(&vendor_package.include_from_upstream, dep_path, false)?,
             &vendor_package
                 .exclude_from_upstream
                 .clone()
@@ -474,6 +474,7 @@ pub fn diff(
             &extend_paths(
                 &vendor_package.include_from_upstream,
                 &vendor_package.target_dir,
+                false,
             )?,
             &vendor_package
                 .exclude_from_upstream
@@ -792,12 +793,13 @@ pub fn copy_recursively(
 pub fn extend_paths(
     include_from_upstream: &[String],
     prefix: impl AsRef<Path>,
+    dir_only: bool,
 ) -> Result<Vec<String>> {
     include_from_upstream
         .iter()
         .map(|pattern| {
             let pattern_long = PathBuf::from(pattern).prefix_paths(prefix.as_ref())?;
-            if pattern_long.is_dir() {
+            if pattern_long.is_dir() && !dir_only {
                 Ok(String::from(pattern_long.join("**").to_str().unwrap()))
             } else {
                 Ok(String::from(pattern_long.to_str().unwrap()))

--- a/src/config.rs
+++ b/src/config.rs
@@ -892,7 +892,7 @@ impl Validate for PartialVendorPackage {
             },
             include_from_upstream: match self.include_from_upstream {
                 Some(include_from_upstream) => include_from_upstream,
-                None => vec![String::from("**")],
+                None => vec![String::from("")],
             },
             exclude_from_upstream: {
                 let mut excl = match self.exclude_from_upstream {


### PR DESCRIPTION
vendor did not handle it well when multiple files/directories were copied together into one (as is done in [croc](https://github.com/pulp-platform/croc/blob/ee968d10696f6081ef8feb82292cda7b2232cdbc/Bender.yml#L173)).

Fixing it involved prioritizing more specific mappings (eg file to file) over less specific ones (dir to dir) and excluding already diffed files when handling their parent directories.

Also fixes an annoying warning caused by a default configuration.

Tested `bender vendor init` and one random patch with `bender vendor patch` in opentitan_peripherals, register_interface, redundancy_cells and croc. The resulting directories were identical to upstream so it is unlikely to break compatibility with existing configurations.  
It should just make it possible to use more elaborate setups without issue.