### PR TITLE
git-checkout: Support branchless commits

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -154,6 +154,13 @@ impl<'git, 'ctx> Git<'ctx> {
             .map(|_| ())
     }
 
+    /// Fetch the specified ref of a remote.
+    pub async fn fetch_ref(self, remote: &str, reference: &str) -> Result<()> {
+        self.spawn_with(|c| c.arg("fetch").arg(remote).arg(reference))
+            .await
+            .map(|_| ())
+    }
+
     /// Stage all local changes.
     pub async fn add_all(self) -> Result<()> {
         self.spawn_with(|c| c.arg("add").arg("--all"))


### PR DESCRIPTION
When creating a database from a git repository, bender currently fetches all branches and tags from the remote before checking out the specified reference. However, it is possible that a commit does not belong to a branch or a tag. For instance, GitHub creates PR merge commits and stores their references in `refs/pull`. To checkout such a branchless commit, it must first be fetched explicitly.

Therefore, when creating the database, explicitly fetch the specified reference in addition to all branches and tags (those are still needed e.g. for `bender update`).

An open corner case is when `Bender.lock` is updated with a branchless commit hash after creating the database, but the manifest is not. This will skip fetching altogether and the database might not contain the desired branchless commit. A possible solution would be to track the modification time of `Bender.lock`; see `manifest_mtime`. However, since this is not the intended use of bender and, in a similar form, already possible today, I chose not to address this for now.

Context: The pulp-action [integrate](https://github.com/pulp-platform/pulp-actions/tree/main/integrate) currently does not work for `pull_request` events, since the run's context (the PR merge commit) is not accessible by the dependent's CI due to the issue addressed by this PR. (see https://github.com/pulp-platform/cva6/actions/runs/10512893871/job/29127223222)