### PR TITLE
Fix copying vendored files when they are symbolic links

### DIFF
--- a/src/cmd/vendor.rs
+++ b/src/cmd/vendor.rs
@@ -757,6 +757,10 @@ pub fn copy_recursively(
         }
 
         let filetype = entry.file_type()?;
+        let canonical_path_filetype =
+            std::fs::metadata(std::fs::canonicalize(entry.path()).unwrap())
+                .unwrap()
+                .file_type();
         if filetype.is_dir() {
             copy_recursively(
                 entry.path(),
@@ -764,7 +768,7 @@ pub fn copy_recursively(
                 includes,
                 ignore,
             )?;
-        } else if filetype.is_symlink() {
+        } else if filetype.is_symlink() && canonical_path_filetype.is_dir() {
             let orig = std::fs::read_link(entry.path());
             symlink_dir(orig.unwrap(), destination.as_ref().join(entry.file_name()))?;
         } else {


### PR DESCRIPTION
I'm working on a project where one vendored dependency uses symlinks for managing different SystemVerilog module versions. This was making bender's vendor commands to try to overwrite the symlink with the actual dereferenced file.

I assume this is not intended and the previous handling of symlinks was only for the special case where a vendored package has a symlink to another external directory. That's why I added another condition where the target of the symlink is an actual directory.