### PR TITLE
git: handle the case where `git tag` opens an editor

### DIFF
--- a/src/sess.rs
+++ b/src/sess.rs
@@ -857,14 +857,26 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
             let tag_name_0 = format!("bender-tmp-{}", revision);
             let tag_name_1 = tag_name_0.clone();
             let git = self.git_database(name, url, false, Some(revision)).await?;
-            git.spawn_with(move |c| c.arg("tag").arg(tag_name_0).arg(revision).arg("--force"))
-		.map_err(move |cause| {
-		    warnln!("Please ensure the commits are available on the remote or run bender update");
-		    Error::chain(format!("Failed to checkout commit {} for {} given in Bender.lock.\n", revision, name),
+            git.spawn_with(move |c| {
+                c.arg("tag")
+                    .arg(tag_name_0)
+                    .arg(revision)
+                    .arg("--force")
+                    .arg("--no-sign")
+            })
+            .map_err(move |cause| {
+                warnln!(
+                    "Please ensure the commits are available on the remote or run bender update"
+                );
+                Error::chain(
+                    format!(
+                        "Failed to checkout commit {} for {} given in Bender.lock.\n",
+                        revision, name
+                    ),
                     cause,
-                    )
-		})
-                .await?;
+                )
+            })
+            .await?;
             git.spawn_with(move |c| {
                 c.arg("clone")
                     .arg(git.path)


### PR DESCRIPTION
For me, the `git tag bender-tmp-<commit> <commit> --force` opens a nano process, which then causes the `bender checkout` to just hang wait for git to complete.

Add a message just to make it go on its merry way.

(An alternate solution would probably be to add `--no-sign`, as this is the cause in my specific case).

cc @niwis 