### PR TITLE
Add .e as a variant of verilog for encrypted verilog

### DIFF
--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -562,7 +562,7 @@ fn emit_template(
             src,
             |f| match f {
                 SourceFile::File(p) => match p.extension().and_then(std::ffi::OsStr::to_str) {
-                    Some("sv") | Some("v") | Some("vp") => Some(SourceType::Verilog),
+                    Some("sv") | Some("v") | Some("vp") | Some("e") => Some(SourceType::Verilog),
                     Some("vhd") | Some("vhdl") => Some(SourceType::Vhdl),
                     _ => None,
                 },


### PR DESCRIPTION
Some IP vendors distribute encrypted verilog IP as .e extension