### PR TITLE
Refactor update command and add new features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Fix `update` failing pull of inexistent commit when multiple repositories are indicated.
 
-# 0.28.2 - 2025-03-31
+### Added
+- `update`: Update repositories in checkout dir if conditions match:
+  - Folder is a git repository
+  - Git state is clean
+  - Commit matches with lockfile
+  - `--ignore-checkout-dir` flag to update IPs ignoring the state inside the checkout directory.
+- `update`: Tell user the lockfile version when solving a conflict.
+
+## 0.28.2 - 2025-03-31
 ### Fixed
 - Put `vcs`, `vsim`, and `riviera` defines in quotes.
 - Fix `genus` script initialization.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
   - `--ignore-checkout-dir` flag to update IPs ignoring the state inside the checkout directory.
 - `update`: Tell user the lockfile version when solving a conflict.
 
+### Changed
+- `update`: Clean up alignment of manual resolution output.
+
 ## 0.28.2 - 2025-03-31
 ### Fixed
 - Put `vcs`, `vsim`, and `riviera` defines in quotes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - `update`: Update repositories in checkout dir if conditions match:
   - Folder is a git repository
   - Git state is clean
-  - Commit matches with lockfile
   - `--ignore-checkout-dir` flag to update IPs ignoring the state inside the checkout directory.
 - `update`: Tell user the lockfile version when solving a conflict.
 - Print dependency updates executed.
+- Enable updating of individual dependencies (and recursive dependencies if desired).
 
 ### Changed
 - `update`: Clean up alignment of manual resolution output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## Unreleased
 ### Fixed
 - Fix `update` failing pull of inexistent commit when multiple repositories are indicated.
+- Fix checkout for commit not yet fetched.
 
 ### Added
 - `update`: Update repositories in checkout dir if conditions match:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
   - Commit matches with lockfile
   - `--ignore-checkout-dir` flag to update IPs ignoring the state inside the checkout directory.
 - `update`: Tell user the lockfile version when solving a conflict.
+- Print dependency updates executed.
 
 ### Changed
 - `update`: Clean up alignment of manual resolution output.
+- `checkout`: When using `checkout_dir`, overwrite existing dependencies if not changed, warning if not checked out, flag to force checkout.
+- `update`: Update `checkout_dir` if no internal changes.
+- Execute checkout instead of clone to checkout correct dependency versions when reasonable.
 
 ## 0.28.2 - 2025-03-31
 ### Fixed

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -153,8 +153,10 @@ pub fn main() -> Result<()> {
             // execute pre-dependency-fetch commands
             if command == "fusesoc" && matches.get_flag("single") {
                 return cmd::fusesoc::run_single(&sess, matches);
-            } else if command == "update" || locked_existing.is_none() {
+            } else if command == "update" {
                 cmd::update::run(matches, &sess, locked_existing.as_ref())?
+            } else if locked_existing.is_none() {
+                cmd::update::run_plain(false, &sess, locked_existing.as_ref())?
             } else {
                 debugln!("main: lockfile {:?} up-to-date", lock_path);
                 locked_existing.unwrap()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -156,7 +156,7 @@ pub fn main() -> Result<()> {
             } else if command == "update" {
                 cmd::update::run(matches, &sess, locked_existing.as_ref())?
             } else if locked_existing.is_none() {
-                cmd::update::run_plain(false, &sess, locked_existing.as_ref())?
+                cmd::update::run_plain(false, &sess, locked_existing.as_ref(), Vec::new())?
             } else {
                 debugln!("main: lockfile {:?} up-to-date", lock_path);
                 (locked_existing.unwrap(), Vec::new())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -154,7 +154,7 @@ pub fn main() -> Result<()> {
             if command == "fusesoc" && matches.get_flag("single") {
                 return cmd::fusesoc::run_single(&sess, matches);
             } else if command == "update" || locked_existing.is_none() {
-                cmd::update::run(&sess)?
+                cmd::update::run(matches, &sess)?
             } else {
                 debugln!("main: lockfile {:?} up-to-date", lock_path);
                 locked_existing.unwrap()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -154,7 +154,7 @@ pub fn main() -> Result<()> {
             if command == "fusesoc" && matches.get_flag("single") {
                 return cmd::fusesoc::run_single(&sess, matches);
             } else if command == "update" || locked_existing.is_none() {
-                cmd::update::run(matches, &sess)?
+                cmd::update::run(matches, &sess, locked_existing.as_ref())?
             } else {
                 debugln!("main: lockfile {:?} up-to-date", lock_path);
                 locked_existing.unwrap()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -156,7 +156,7 @@ pub fn main() -> Result<()> {
             } else if command == "update" {
                 cmd::update::run(matches, &sess, locked_existing.as_ref())?
             } else if locked_existing.is_none() {
-                cmd::update::run_plain(false, &sess, locked_existing.as_ref(), Vec::new())?
+                cmd::update::run_plain(false, &sess, locked_existing.as_ref(), IndexSet::new())?
             } else {
                 debugln!("main: lockfile {:?} up-to-date", lock_path);
                 (locked_existing.unwrap(), Vec::new())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,16 +17,13 @@ use dunce::canonicalize;
 use clap::parser::ValuesRef;
 use clap::{Arg, ArgAction, Command};
 use serde_yaml;
+use tokio::runtime::Runtime;
 
 use crate::cmd;
-use crate::config::{
-    Config, Locked, LockedPackage, LockedSource, Manifest, Merge, PartialConfig, PrefixPaths,
-    Validate,
-};
+use crate::config::{Config, Manifest, Merge, PartialConfig, PrefixPaths, Validate};
 use crate::error::*;
-use crate::resolver::DependencyResolver;
+use crate::lockfile::*;
 use crate::sess::{Session, SessionArenas, SessionIo};
-use tokio::runtime::Runtime;
 
 /// Inner main function which can return an error.
 pub fn main() -> Result<()> {
@@ -56,25 +53,7 @@ pub fn main() -> Result<()> {
                 .action(ArgAction::SetTrue)
                 .help("Disables fetching of remotes (e.g. for air-gapped computers)"),
         )
-        .subcommand(
-            Command::new("update")
-                .about("Update the dependencies")
-                .arg(
-                    Arg::new("fetch")
-                        .short('f')
-                        .long("fetch")
-                        .num_args(0)
-                        .action(ArgAction::SetTrue)
-                        .help("forces fetch of git dependencies"),
-                )
-                .arg(
-                    Arg::new("no-checkout")
-                        .long("no-checkout")
-                        .num_args(0)
-                        .action(ArgAction::SetTrue)
-                        .help("Disables checkout of dependencies"),
-                ),
-        )
+        .subcommand(cmd::update::new())
         .subcommand(cmd::path::new())
         .subcommand(cmd::parents::new())
         .subcommand(cmd::clone::new())
@@ -121,12 +100,7 @@ pub fn main() -> Result<()> {
 
     let mut force_fetch = false;
     if let Some(("update", intern_matches)) = matches.subcommand() {
-        force_fetch = intern_matches.get_flag("fetch");
-        if matches.get_flag("local") && intern_matches.get_flag("fetch") {
-            warnln!(
-                "As --local argument is set for bender command, no fetching will be performed."
-            );
-        }
+        force_fetch = cmd::update::setup(intern_matches)?;
     }
 
     // Determine the root working directory, which has either been provided via
@@ -180,18 +154,7 @@ pub fn main() -> Result<()> {
             if command == "fusesoc" && matches.get_flag("single") {
                 return cmd::fusesoc::run_single(&sess, matches);
             } else if command == "update" || locked_existing.is_none() {
-                if manifest.frozen {
-                    return Err(Error::new(format!(
-                        "Refusing to update dependencies because the package is frozen.
-                        Remove the `frozen: true` from {:?} to proceed; there be dragons.",
-                        manifest_path
-                    )));
-                }
-                debugln!("main: lockfile {:?} outdated", lock_path);
-                let res = DependencyResolver::new(&sess);
-                let locked_new = res.resolve()?;
-                write_lockfile(&locked_new, &root_dir.join("Bender.lock"), &root_dir)?;
-                locked_new
+                cmd::update::run(&sess)?
             } else {
                 debugln!("main: lockfile {:?} up-to-date", lock_path);
                 locked_existing.unwrap()
@@ -489,78 +452,6 @@ fn maybe_load_config(path: &Path, warn_config_loaded: bool) -> Result<Option<Par
         warnln!("Using config at {:?} for overrides.", path)
     };
     Ok(Some(partial.prefix_paths(path.parent().unwrap())?))
-}
-
-/// Read a lock file.
-fn read_lockfile(path: &Path, root_dir: &Path) -> Result<Locked> {
-    debugln!("read_lockfile: {:?}", path);
-    use std::fs::File;
-    let file = File::open(path)
-        .map_err(|cause| Error::chain(format!("Cannot open lockfile {:?}.", path), cause))?;
-    let locked_loaded: Result<Locked> = serde_yaml::from_reader(file)
-        .map_err(|cause| Error::chain(format!("Syntax error in lockfile {:?}.", path), cause));
-    // Make relative paths absolute
-    Ok(Locked {
-        packages: locked_loaded?
-            .packages
-            .iter()
-            .map(|pack| {
-                Ok(if let LockedSource::Path(path) = &pack.1.source {
-                    (
-                        pack.0.clone(),
-                        LockedPackage {
-                            revision: pack.1.revision.clone(),
-                            version: pack.1.version.clone(),
-                            source: LockedSource::Path(if path.is_relative() {
-                                path.clone().prefix_paths(root_dir)?
-                            } else {
-                                path.clone()
-                            }),
-                            dependencies: pack.1.dependencies.clone(),
-                        },
-                    )
-                } else {
-                    (pack.0.clone(), pack.1.clone())
-                })
-            })
-            .collect::<Result<_>>()?,
-    })
-}
-
-/// Write a lock file.
-fn write_lockfile(locked: &Locked, path: &Path, root_dir: &Path) -> Result<()> {
-    debugln!("write_lockfile: {:?}", path);
-    // Adapt paths within main repo to be relative
-    let adapted_locked = Locked {
-        packages: locked
-            .packages
-            .iter()
-            .map(|pack| {
-                if let LockedSource::Path(path) = &pack.1.source {
-                    (
-                        pack.0.clone(),
-                        LockedPackage {
-                            revision: pack.1.revision.clone(),
-                            version: pack.1.version.clone(),
-                            source: LockedSource::Path(
-                                path.strip_prefix(root_dir).unwrap_or(path).to_path_buf(),
-                            ),
-                            dependencies: pack.1.dependencies.clone(),
-                        },
-                    )
-                } else {
-                    (pack.0.clone(), pack.1.clone())
-                }
-            })
-            .collect(),
-    };
-
-    use std::fs::File;
-    let file = File::create(path)
-        .map_err(|cause| Error::chain(format!("Cannot create lockfile {:?}.", path), cause))?;
-    serde_yaml::to_writer(file, &adapted_locked)
-        .map_err(|cause| Error::chain(format!("Cannot write lockfile {:?}.", path), cause))?;
-    Ok(())
 }
 
 /// Execute a plugin.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,6 +16,7 @@ use dunce::canonicalize;
 
 use clap::parser::ValuesRef;
 use clap::{Arg, ArgAction, Command};
+use indexmap::IndexSet;
 use serde_yaml;
 use tokio::runtime::Runtime;
 

--- a/src/cmd/checkout.rs
+++ b/src/cmd/checkout.rs
@@ -23,10 +23,15 @@ pub fn new() -> Command {
 }
 
 /// Execute the `checkout` subcommand.
-pub fn run(sess: &Session, matches: &ArgMatches, forcibly: bool) -> Result<()> {
+pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
+    run_plain(sess, matches.get_flag("forcibly"), &[])
+}
+
+/// Execute a checkout (for the `checkout` subcommand).
+pub fn run_plain(sess: &Session, forcibly: bool, update_list: &[String]) -> Result<()> {
     let rt = Runtime::new()?;
     let io = SessionIo::new(sess);
-    let _srcs = rt.block_on(io.sources(forcibly || matches.get_flag("forcibly")))?;
+    let _srcs = rt.block_on(io.sources(forcibly, update_list))?;
 
     Ok(())
 }

--- a/src/cmd/checkout.rs
+++ b/src/cmd/checkout.rs
@@ -15,7 +15,7 @@ pub fn new() -> Command {
     .about("Checkout all dependencies referenced in the Lock file")
     .arg(
         Arg::new("forcibly")
-            .long("checkout-force")
+            .long("force")
             .num_args(0)
             .action(ArgAction::SetTrue)
             .help("Force update of dependencies in a custom checkout_dir. Please use carefully to avoid losing work."),

--- a/src/cmd/checkout.rs
+++ b/src/cmd/checkout.rs
@@ -3,7 +3,7 @@
 
 //! The `checkout` subcommand.
 
-use clap::{ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use tokio::runtime::Runtime;
 
 use crate::error::*;
@@ -11,14 +11,22 @@ use crate::sess::{Session, SessionIo};
 
 /// Assemble the `checkout` subcommand.
 pub fn new() -> Command {
-    Command::new("checkout").about("Checkout all dependencies referenced in the Lock file")
+    Command::new("checkout")
+    .about("Checkout all dependencies referenced in the Lock file")
+    .arg(
+        Arg::new("forcibly")
+            .long("checkout-force")
+            .num_args(0)
+            .action(ArgAction::SetTrue)
+            .help("Force update of dependencies in a custom checkout_dir. Please use carefully to avoid losing work."),
+    )
 }
 
 /// Execute the `checkout` subcommand.
-pub fn run(sess: &Session, _matches: &ArgMatches) -> Result<()> {
+pub fn run(sess: &Session, matches: &ArgMatches, forcibly: bool) -> Result<()> {
     let rt = Runtime::new()?;
     let io = SessionIo::new(sess);
-    let _srcs = rt.block_on(io.sources())?;
+    let _srcs = rt.block_on(io.sources(forcibly || matches.get_flag("forcibly")))?;
 
     Ok(())
 }

--- a/src/cmd/clone.rs
+++ b/src/cmd/clone.rs
@@ -86,7 +86,7 @@ pub fn run(sess: &Session, path: &Path, matches: &ArgMatches) -> Result<()> {
         let checkouts = rt
             .block_on(join_all(
                 ids.iter()
-                    .map(|&(_, id)| io.checkout(id))
+                    .map(|&(_, id)| io.checkout(id, false))
                     .collect::<Vec<_>>(),
             ))
             .into_iter()

--- a/src/cmd/clone.rs
+++ b/src/cmd/clone.rs
@@ -86,7 +86,7 @@ pub fn run(sess: &Session, path: &Path, matches: &ArgMatches) -> Result<()> {
         let checkouts = rt
             .block_on(join_all(
                 ids.iter()
-                    .map(|&(_, id)| io.checkout(id, false))
+                    .map(|&(_, id)| io.checkout(id, false, &[]))
                     .collect::<Vec<_>>(),
             ))
             .into_iter()

--- a/src/cmd/fusesoc.rs
+++ b/src/cmd/fusesoc.rs
@@ -183,7 +183,7 @@ pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
 
     let rt = Runtime::new()?;
     let io = SessionIo::new(sess);
-    let srcs = rt.block_on(io.sources())?;
+    let srcs = rt.block_on(io.sources(false))?;
 
     let dep_pkgs = sess.packages();
     let mut pkg_manifest_paths = dep_pkgs

--- a/src/cmd/fusesoc.rs
+++ b/src/cmd/fusesoc.rs
@@ -183,7 +183,7 @@ pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
 
     let rt = Runtime::new()?;
     let io = SessionIo::new(sess);
-    let srcs = rt.block_on(io.sources(false))?;
+    let srcs = rt.block_on(io.sources(false, &[]))?;
 
     let dep_pkgs = sess.packages();
     let mut pkg_manifest_paths = dep_pkgs

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -18,4 +18,5 @@ pub mod parents;
 pub mod path;
 pub mod script;
 pub mod sources;
+pub mod update;
 pub mod vendor;

--- a/src/cmd/parents.rs
+++ b/src/cmd/parents.rs
@@ -54,7 +54,7 @@ pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
             let all_deps = deps.iter().map(|&id| sess.dependency(id));
             for current_dep in all_deps {
                 if dep == current_dep.name.as_str() {
-                    let dep_manifest = rt.block_on(io.dependency_manifest(pkg)).unwrap();
+                    let dep_manifest = rt.block_on(io.dependency_manifest(pkg, false)).unwrap();
                     // Filter out dependencies without a manifest
                     if dep_manifest.is_none() {
                         warnln!("{} is shown to include dependency, but manifest does not have this information.", pkg_name.to_string());

--- a/src/cmd/parents.rs
+++ b/src/cmd/parents.rs
@@ -54,7 +54,9 @@ pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
             let all_deps = deps.iter().map(|&id| sess.dependency(id));
             for current_dep in all_deps {
                 if dep == current_dep.name.as_str() {
-                    let dep_manifest = rt.block_on(io.dependency_manifest(pkg, false)).unwrap();
+                    let dep_manifest = rt
+                        .block_on(io.dependency_manifest(pkg, false, &[]))
+                        .unwrap();
                     // Filter out dependencies without a manifest
                     if dep_manifest.is_none() {
                         warnln!("{} is shown to include dependency, but manifest does not have this information.", pkg_name.to_string());

--- a/src/cmd/path.rs
+++ b/src/cmd/path.rs
@@ -52,7 +52,7 @@ pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
         let checkouts = rt
             .block_on(join_all(
                 ids.iter()
-                    .map(|&(_, id)| io.checkout(id, false))
+                    .map(|&(_, id)| io.checkout(id, false, &[]))
                     .collect::<Vec<_>>(),
             ))
             .into_iter()

--- a/src/cmd/path.rs
+++ b/src/cmd/path.rs
@@ -52,7 +52,7 @@ pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
         let checkouts = rt
             .block_on(join_all(
                 ids.iter()
-                    .map(|&(_, id)| io.checkout(id))
+                    .map(|&(_, id)| io.checkout(id, false))
                     .collect::<Vec<_>>(),
             ))
             .into_iter()

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -205,7 +205,7 @@ where
 pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
     let rt = Runtime::new()?;
     let io = SessionIo::new(sess);
-    let mut srcs = rt.block_on(io.sources(false))?;
+    let mut srcs = rt.block_on(io.sources(false, &[]))?;
 
     // Format-specific target specifiers.
     let vivado_targets = &["vivado", "fpga", "xilinx"];

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -205,7 +205,7 @@ where
 pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
     let rt = Runtime::new()?;
     let io = SessionIo::new(sess);
-    let mut srcs = rt.block_on(io.sources())?;
+    let mut srcs = rt.block_on(io.sources(false))?;
 
     // Format-specific target specifiers.
     let vivado_targets = &["vivado", "fpga", "xilinx"];

--- a/src/cmd/sources.rs
+++ b/src/cmd/sources.rs
@@ -86,7 +86,7 @@ where
 pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
     let rt = Runtime::new()?;
     let io = SessionIo::new(sess);
-    let mut srcs = rt.block_on(io.sources(false))?;
+    let mut srcs = rt.block_on(io.sources(false, &[]))?;
 
     if matches.get_flag("raw") {
         let stdout = std::io::stdout();

--- a/src/cmd/sources.rs
+++ b/src/cmd/sources.rs
@@ -86,7 +86,7 @@ where
 pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
     let rt = Runtime::new()?;
     let io = SessionIo::new(sess);
-    let mut srcs = rt.block_on(io.sources())?;
+    let mut srcs = rt.block_on(io.sources(false))?;
 
     if matches.get_flag("raw") {
         let stdout = std::io::stdout();

--- a/src/cmd/update.rs
+++ b/src/cmd/update.rs
@@ -5,6 +5,7 @@
 
 use clap::{Arg, ArgAction, ArgMatches, Command};
 
+use crate::cmd;
 use crate::config::Locked;
 use crate::error::*;
 use crate::lockfile::*;
@@ -69,4 +70,13 @@ pub fn run<'ctx>(
     let locked_new = res.resolve(existing, matches.get_flag("ignore-checkout-dir"))?;
     write_lockfile(&locked_new, &sess.root.join("Bender.lock"), sess.root)?;
     Ok(locked_new)
+}
+
+/// Execute the final checkout (if not disabled).
+pub fn run_final<'ctx>(sess: &'ctx Session<'ctx>, matches: &ArgMatches) -> Result<()> {
+    if matches.get_flag("no-checkout") {
+        Ok(())
+    } else {
+        cmd::checkout::run(sess, matches, true)
+    }
 }

--- a/src/cmd/update.rs
+++ b/src/cmd/update.rs
@@ -30,6 +30,13 @@ pub fn new() -> Command {
                 .action(ArgAction::SetTrue)
                 .help("Disables checkout of dependencies"),
         )
+        .arg(
+            Arg::new("ignore-checkout-dir")
+                .long("ignore-checkout-dir")
+                .num_args(0)
+                .action(ArgAction::SetTrue)
+                .help("Overwrites modified dependencies in `checkout_dir` if specified"),
+        )
 }
 
 /// Execute the `update` subcommand.
@@ -42,7 +49,7 @@ pub fn setup(matches: &ArgMatches) -> Result<bool> {
 }
 
 /// Execute an update (for the `update` subcommand or because no lockfile exists).
-pub fn run<'ctx>(sess: &'ctx Session<'ctx>) -> Result<Locked> {
+pub fn run<'ctx>(matches: &ArgMatches, sess: &'ctx Session<'ctx>) -> Result<Locked> {
     if sess.manifest.frozen {
         return Err(Error::new(format!(
             "Refusing to update dependencies because the package is frozen.
@@ -55,7 +62,7 @@ pub fn run<'ctx>(sess: &'ctx Session<'ctx>) -> Result<Locked> {
         sess.root.join("Bender.lock")
     );
     let res = DependencyResolver::new(sess);
-    let locked_new = res.resolve()?;
+    let locked_new = res.resolve(matches.get_flag("ignore-checkout-dir"))?;
     write_lockfile(&locked_new, &sess.root.join("Bender.lock"), sess.root)?;
     Ok(locked_new)
 }

--- a/src/cmd/update.rs
+++ b/src/cmd/update.rs
@@ -1,0 +1,61 @@
+// Copyright (c) 2024 ETH Zurich
+// Michael Rogenmoser <michaero@iis.ee.ethz.ch>
+
+//! The `update` subcommand.
+
+use clap::{Arg, ArgAction, ArgMatches, Command};
+
+use crate::config::Locked;
+use crate::error::*;
+use crate::lockfile::*;
+use crate::resolver::DependencyResolver;
+use crate::sess::Session;
+
+/// Assemble the `update` subcommand.
+pub fn new() -> Command {
+    Command::new("update")
+        .about("Update the dependencies")
+        .arg(
+            Arg::new("fetch")
+                .short('f')
+                .long("fetch")
+                .num_args(0)
+                .action(ArgAction::SetTrue)
+                .help("forces fetch of git dependencies"),
+        )
+        .arg(
+            Arg::new("no-checkout")
+                .long("no-checkout")
+                .num_args(0)
+                .action(ArgAction::SetTrue)
+                .help("Disables checkout of dependencies"),
+        )
+}
+
+/// Execute the `update` subcommand.
+pub fn setup(matches: &ArgMatches) -> Result<bool> {
+    let force_fetch = matches.get_flag("fetch");
+    if matches.get_flag("local") && matches.get_flag("fetch") {
+        warnln!("As --local argument is set for bender command, no fetching will be performed.");
+    }
+    Ok(force_fetch)
+}
+
+/// Execute an update (for the `update` subcommand or because no lockfile exists).
+pub fn run<'ctx>(sess: &'ctx Session<'ctx>) -> Result<Locked> {
+    if sess.manifest.frozen {
+        return Err(Error::new(format!(
+            "Refusing to update dependencies because the package is frozen.
+            Remove the `frozen: true` from {:?} to proceed; there be dragons.",
+            sess.root.join("Bender.yml")
+        )));
+    }
+    debugln!(
+        "main: lockfile {:?} outdated",
+        sess.root.join("Bender.lock")
+    );
+    let res = DependencyResolver::new(sess);
+    let locked_new = res.resolve()?;
+    write_lockfile(&locked_new, &sess.root.join("Bender.lock"), sess.root)?;
+    Ok(locked_new)
+}

--- a/src/cmd/update.rs
+++ b/src/cmd/update.rs
@@ -49,7 +49,11 @@ pub fn setup(matches: &ArgMatches) -> Result<bool> {
 }
 
 /// Execute an update (for the `update` subcommand or because no lockfile exists).
-pub fn run<'ctx>(matches: &ArgMatches, sess: &'ctx Session<'ctx>) -> Result<Locked> {
+pub fn run<'ctx>(
+    matches: &ArgMatches,
+    sess: &'ctx Session<'ctx>,
+    existing: Option<&'ctx Locked>,
+) -> Result<Locked> {
     if sess.manifest.frozen {
         return Err(Error::new(format!(
             "Refusing to update dependencies because the package is frozen.
@@ -62,7 +66,7 @@ pub fn run<'ctx>(matches: &ArgMatches, sess: &'ctx Session<'ctx>) -> Result<Lock
         sess.root.join("Bender.lock")
     );
     let res = DependencyResolver::new(sess);
-    let locked_new = res.resolve(matches.get_flag("ignore-checkout-dir"))?;
+    let locked_new = res.resolve(existing, matches.get_flag("ignore-checkout-dir"))?;
     write_lockfile(&locked_new, &sess.root.join("Bender.lock"), sess.root)?;
     Ok(locked_new)
 }

--- a/src/cmd/update.rs
+++ b/src/cmd/update.rs
@@ -7,6 +7,7 @@ use std::collections::BTreeMap;
 use std::io::Write;
 
 use clap::{Arg, ArgAction, ArgMatches, Command};
+use indexmap::IndexSet;
 use tabwriter::TabWriter;
 
 use crate::cmd;
@@ -54,7 +55,9 @@ pub fn new() -> Command {
                 .num_args(0)
                 .action(ArgAction::SetTrue)
                 .requires("dep")
-                .help("Update requested dependencies recursively, i.e., including their dependencies"),
+                .help(
+                    "Update requested dependencies recursively, i.e., including their dependencies",
+                ),
         )
 }
 

--- a/src/cmd/update.rs
+++ b/src/cmd/update.rs
@@ -67,7 +67,14 @@ pub fn run<'ctx>(
         sess.root.join("Bender.lock")
     );
     let res = DependencyResolver::new(sess);
-    let locked_new = res.resolve(existing, matches.get_flag("ignore-checkout-dir"))?;
+    let locked_new = res.resolve(
+        existing,
+        if matches.contains_id("ignore-checkout-dir") {
+            matches.get_flag("ignore-checkout-dir")
+        } else {
+            false
+        },
+    )?;
     write_lockfile(&locked_new, &sess.root.join("Bender.lock"), sess.root)?;
     Ok(locked_new)
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -240,6 +240,13 @@ impl<'git, 'ctx> Git<'ctx> {
             .map(|raw| raw.lines().take(1).map(String::from).next())
     }
 
+    /// Determine the url of a remote.
+    pub async fn remote_url(self, remote: &str) -> Result<String> {
+        self.spawn_with(|c| c.arg("remote").arg("get-url").arg(remote))
+            .await
+            .map(|raw| raw.lines().take(1).map(String::from).next().unwrap())
+    }
+
     /// List files in the directory.
     ///
     /// Calls `git ls-tree` under the hood.

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1,0 +1,80 @@
+// Copyright (c) 2024 ETH Zurich
+// Michael Rogenmoser <michaero@iis.ee.ethz.ch>
+
+use std;
+use std::path::Path;
+
+use crate::config::{Locked, LockedPackage, LockedSource, PrefixPaths};
+use crate::error::*;
+
+/// Read a lock file.
+pub fn read_lockfile(path: &Path, root_dir: &Path) -> Result<Locked> {
+    debugln!("read_lockfile: {:?}", path);
+    use std::fs::File;
+    let file = File::open(path)
+        .map_err(|cause| Error::chain(format!("Cannot open lockfile {:?}.", path), cause))?;
+    let locked_loaded: Result<Locked> = serde_yaml::from_reader(file)
+        .map_err(|cause| Error::chain(format!("Syntax error in lockfile {:?}.", path), cause));
+    // Make relative paths absolute
+    Ok(Locked {
+        packages: locked_loaded?
+            .packages
+            .iter()
+            .map(|pack| {
+                Ok(if let LockedSource::Path(path) = &pack.1.source {
+                    (
+                        pack.0.clone(),
+                        LockedPackage {
+                            revision: pack.1.revision.clone(),
+                            version: pack.1.version.clone(),
+                            source: LockedSource::Path(if path.is_relative() {
+                                path.clone().prefix_paths(root_dir)?
+                            } else {
+                                path.clone()
+                            }),
+                            dependencies: pack.1.dependencies.clone(),
+                        },
+                    )
+                } else {
+                    (pack.0.clone(), pack.1.clone())
+                })
+            })
+            .collect::<Result<_>>()?,
+    })
+}
+
+/// Write a lock file.
+pub fn write_lockfile(locked: &Locked, path: &Path, root_dir: &Path) -> Result<()> {
+    debugln!("write_lockfile: {:?}", path);
+    // Adapt paths within main repo to be relative
+    let adapted_locked = Locked {
+        packages: locked
+            .packages
+            .iter()
+            .map(|pack| {
+                if let LockedSource::Path(path) = &pack.1.source {
+                    (
+                        pack.0.clone(),
+                        LockedPackage {
+                            revision: pack.1.revision.clone(),
+                            version: pack.1.version.clone(),
+                            source: LockedSource::Path(
+                                path.strip_prefix(root_dir).unwrap_or(path).to_path_buf(),
+                            ),
+                            dependencies: pack.1.dependencies.clone(),
+                        },
+                    )
+                } else {
+                    (pack.0.clone(), pack.1.clone())
+                }
+            })
+            .collect(),
+    };
+
+    use std::fs::File;
+    let file = File::create(path)
+        .map_err(|cause| Error::chain(format!("Cannot create lockfile {:?}.", path), cause))?;
+    serde_yaml::to_writer(file, &adapted_locked)
+        .map_err(|cause| Error::chain(format!("Cannot write lockfile {:?}.", path), cause))?;
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ pub mod cmd;
 pub mod config;
 // pub mod future_throttle;
 pub mod git;
+pub mod lockfile;
 pub mod resolver;
 #[allow(clippy::bind_instead_of_map)]
 pub mod sess;

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -77,7 +77,7 @@ impl<'ctx> DependencyResolver<'ctx> {
         mut self,
         existing: Option<&'ctx Locked>,
         ignore_checkout: bool,
-        keep_locked: Vec<&'ctx String>,
+        keep_locked: IndexSet<&'ctx String>,
     ) -> Result<Locked> {
         let rt = Runtime::new()?;
         let io = SessionIo::new(self.sess);
@@ -367,7 +367,7 @@ impl<'ctx> DependencyResolver<'ctx> {
     fn register_dependencies_in_lockfile(
         &mut self,
         locked: &'ctx Locked,
-        keep_locked: Vec<&'ctx String>,
+        keep_locked: IndexSet<&'ctx String>,
         rt: &Runtime,
         io: &SessionIo<'ctx, 'ctx>,
     ) -> Result<()> {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -109,6 +109,7 @@ impl<'ctx> DependencyResolver<'ctx> {
                     if !ignore_checkout {
                         if !is_git_repo {
                             warnln!("Dependency `{}` in checkout_dir `{}` is not a git repository. Setting as path dependency.\n\
+                                    \tPlease use `bender clone` to work on git dependencies.\n\
                                     \tRun `bender update --ignore-checkout-dir` to overwrite this at your own risk.",
                                 dir.as_ref().unwrap().path().file_name().unwrap().to_str().unwrap(),
                                 &checkout.display());

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -635,6 +635,13 @@ impl<'ctx> DependencyResolver<'ctx> {
                         cons.push((con, dsrc));
                     }
                     cons = cons.into_iter().unique().collect();
+                    if let Some((cnstr, src, _)) = self.locked.get(name) {
+                        let _ = write!(
+                            msg,
+                            "\n\nThe previous lockfile required `{}` at `{}`",
+                            cnstr, src
+                        );
+                    }
                     // Let user resolve conflict if both stderr and stdin go to a TTY.
                     if std::io::stderr().is_terminal() && std::io::stdin().is_terminal() {
                         let decision = if let Some(d) = self.decisions.get(name) {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -123,7 +123,8 @@ impl<'ctx> DependencyResolver<'ctx> {
                                 .stdout
                                 .is_empty()))
                     {
-                        warnln!("Dependency `{}` in checkout_dir `{}` is not in a clean state. Setting as path dependency.",
+                        warnln!("Dependency `{}` in checkout_dir `{}` is not in a clean state. Setting as path dependency.\n\
+                                    \tTo override this behavior, use `bender update --ignore-checkout-dir`.",
                             dir.as_ref().unwrap().path().file_name().unwrap().to_str().unwrap(),
                             &checkout.display());
                         self.checked_out

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -462,7 +462,6 @@ impl<'ctx> DependencyResolver<'ctx> {
             };
 
             self.register_locked_dependency(dep, depref, depversions, locked_index);
-            println!("Locked {} at {}", dep, locked_index);
         }
         Ok(())
     }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -124,7 +124,7 @@ impl<'ctx> DependencyResolver<'ctx> {
                                 .is_empty()))
                     {
                         warnln!("Dependency `{}` in checkout_dir `{}` is not in a clean state. Setting as path dependency.\n\
-                                    \tTo override this behavior, use `bender update --ignore-checkout-dir`.",
+                                    \tRun `bender update --ignore-checkout-dir` to overwrite this at your own risk.",
                             dir.as_ref().unwrap().path().file_name().unwrap().to_str().unwrap(),
                             &checkout.display());
                         self.checked_out

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -479,6 +479,16 @@ impl<'ctx> DependencyResolver<'ctx> {
                         self.impose(name, con, src, &cons, rt, io)?;
                         count += 1;
                         table_item.picked_source = Some(*id);
+                    } else {
+                        match self.impose(name, con, src, &cons, rt, io) {
+                            Ok(_) => {
+                                count += 1;
+                                table_item.picked_source = Some(*id);
+                            }
+                            Err(cause) => {
+                                warnln!("{}", cause);
+                            }
+                        };
                     }
                 }
                 debugln!(

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -17,7 +17,7 @@ use is_terminal::IsTerminal;
 use itertools::Itertools;
 use tokio::runtime::Runtime;
 
-use crate::config::{self, Manifest};
+use crate::config::{self, Locked, LockedPackage, LockedSource, Manifest};
 use crate::error::*;
 use crate::sess::{
     DependencyConstraint, DependencyRef, DependencySource, DependencyVersion, DependencyVersions,
@@ -139,10 +139,10 @@ impl<'ctx> DependencyResolver<'ctx> {
                             DependencySource::Path(p) => p,
                             _ => unreachable!(),
                         };
-                        config::LockedPackage {
+                        LockedPackage {
                             revision: None,
                             version: None,
-                            source: config::LockedSource::Path(path),
+                            source: LockedSource::Path(path),
                             dependencies: deps,
                         }
                     }
@@ -166,10 +166,10 @@ impl<'ctx> DependencyResolver<'ctx> {
                             .map(|(v, _)| v)
                             .max()
                             .map(|v| v.to_string());
-                        config::LockedPackage {
+                        LockedPackage {
                             revision: Some(String::from(rev)),
                             version,
-                            source: config::LockedSource::Git(url),
+                            source: LockedSource::Git(url),
                             dependencies: deps,
                         }
                     }
@@ -177,7 +177,7 @@ impl<'ctx> DependencyResolver<'ctx> {
                 Ok((name.to_string(), pkg))
             })
             .collect::<Result<_>>()?;
-        Ok(config::Locked { packages })
+        Ok(Locked { packages })
     }
 
     fn register_dependency(

--- a/src/sess.rs
+++ b/src/sess.rs
@@ -126,13 +126,13 @@ impl<'sess, 'ctx: 'sess> Session<'ctx> {
         &self,
         name: &str,
         cfg: &config::Dependency,
-        manifest: &config::Manifest,
+        calling_package: &str,
     ) -> DependencyRef {
         debugln!(
             "sess: load dependency `{}` as {:?} for package `{}`",
             name,
             cfg,
-            manifest.package.name
+            calling_package
         );
         let src = DependencySource::from(cfg);
         self.deps

--- a/src/sess.rs
+++ b/src/sess.rs
@@ -800,23 +800,22 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
     ) -> Result<&'ctx Path> {
         let clear = if path.exists() {
             // Scrap checkouts with the wrong tag.
-            let checkout_already_good =
-                Git::new(path, &self.sess.config.git, self.sess.git_throttle.clone())
-                    .current_checkout()
-                    .then(|current| async {
-                        match current {
-                            Ok(Some(current)) => {
-                                debugln!(
-                                    "checkout_git: currently `{}` (want `{}`)",
-                                    current,
-                                    revision
-                                );
-                                current != revision
-                            }
-                            _ => true,
+            let checkout_already_good = Git::new(path, &self.sess.config.git)
+                .current_checkout()
+                .then(|current| async {
+                    match current {
+                        Ok(Some(current)) => {
+                            debugln!(
+                                "checkout_git: currently `{}` (want `{}`)",
+                                current,
+                                revision
+                            );
+                            current != revision
                         }
-                    })
-                    .await;
+                        _ => true,
+                    }
+                })
+                .await;
 
             // Never scrap checkouts the user asked for explicitly in
             // the workspace configuration.

--- a/src/sess.rs
+++ b/src/sess.rs
@@ -807,6 +807,13 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
                     // Never scrap checkouts the user asked for explicitly in
                     // the workspace configuration.
                     if self.sess.manifest.workspace.checkout_dir.is_some() && !forcibly {
+                        // TODO: If is git repo, remote source is correct, and no unstaged changes, do a fetch and checkout (without cleaning the repo).
+                        warnln!(
+                            "Workspace checkout directory set, not updating {} at {}.\n\
+                            \tTo ensure proper checkout you may need to run `bender checkout --force`.",
+                            name,
+                            path.display()
+                        );
                         return Ok(false);
                     }
 


### PR DESCRIPTION
### Fixed
- Fix `update` failing pull of inexistent commit when multiple repositories are indicated.
- Fix checkout for commit not yet fetched.

### Added
- `update`: Update repositories in checkout dir if conditions match:
  - Folder is a git repository
  - Git state is clean
  - `--ignore-checkout-dir` flag to update IPs ignoring the state inside the checkout directory.
- `update`: Tell user the lockfile version when solving a conflict.
- Print dependency updates executed.
- Enable updating of individual dependencies (and recursive dependencies if desired).

### Changed
- `update`: Clean up alignment of manual resolution output.
- `checkout`: When using `checkout_dir`, overwrite existing dependencies if not changed, warning if not checked out, flag to force checkout.
- `update`: Update `checkout_dir` if no internal changes.
- Execute checkout instead of clone to checkout correct dependency versions when reasonable.
