### PR TITLE
tmpl: Fix prefix for genus include paths

### DIFF
--- a/src/script_fmt/genus_tcl.tera
+++ b/src/script_fmt/genus_tcl.tera
@@ -7,7 +7,7 @@ if [ info exists search_path ] {
 set ROOT "{{ root }}"
 {% if compilation_mode == 'separate' %}{% for group in srcs %}
 set search_path $search_path_initial
-{% for incdir in group.incdirs %}lappend search_path "$ROOT{{ incdir | replace(from=root, to='') }}"
+{% for incdir in group.incdirs %}lappend search_path "{{ incdir | replace(from=root, to='$ROOT') }}"
 {% endfor %}set_db init_hdl_search_path $search_path
 
 {% if group.file_type == 'verilog' %}read_hdl -language sv \


### PR DESCRIPTION
This is the same change as in [this commit](https://github.com/pulp-platform/bender/commit/abe9d6825cf4119aea55d663e9159b36e3292f17) but for Genus. Local paths still included $ROOT, while the local path is already normalized. 