### PR TITLE
Print which file failed to canonicalize

### DIFF
--- a/src/cmd/vendor.rs
+++ b/src/cmd/vendor.rs
@@ -758,7 +758,7 @@ pub fn copy_recursively(
 
         let filetype = entry.file_type()?;
         let canonical_path_filetype =
-            std::fs::metadata(std::fs::canonicalize(entry.path()).unwrap())
+            std::fs::metadata(std::fs::canonicalize(entry.path()).expect(format!("Failed to canonicalize {}.", entry.path().to_str().unwrap()).as_str()))
                 .unwrap()
                 .file_type();
         if filetype.is_dir() {


### PR DESCRIPTION
Assume following configuration file:

```
package:
  name: test

vendor_package:
  - name: pulp
    target_dir: vendor_ips/pulp
    upstream: { git: "https://github.com/pulp-platform/pulp.git", rev: "b6ae54700b76395b049742ebfc52c5aaf6e148a5" }
    include_from_upstream:
      - "rtl/tb/dpi_models"
```

File `dpi_models` is a symbolic link that does not point to a valid file.

Currently the error message is following:

```
     Cloning pulp (https://github.com/pulp-platform/pulp.git)
     Copying pulp files from upstream
warning: rtl/tb/dpi_models not found in upstream, continuing.

thread 'main' panicked at src/cmd/vendor.rs:761:67:
called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This error message does not explicitely point out which file is particularly the problem.

With commits the error message is following:

```
     Cloning pulp (https://github.com/pulp-platform/pulp.git)
     Copying pulp files from upstream
warning: rtl/tb/dpi_models not found in upstream, continuing.

thread 'main' panicked at src/cmd/vendor.rs:761:67:
Failed to canonicalize /tmp/.tmpfVhsq9/rtl/tb/dpi_models.: Os { code: 2, kind: NotFound, message: "No such file or directory" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
