### PR TITLE
Add more helpful information printed in subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - `checkout`: When using `checkout_dir`, overwrite existing dependencies if not changed, warning if not checked out, flag to force checkout.
 - `update`: Update `checkout_dir` if no internal changes.
 - Execute checkout instead of clone to checkout correct dependency versions when reasonable.
+- `packages --graph`: Clean up alignment of output.
 
 ## 0.28.2 - 2025-03-31
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Add support for glob in manifest source files.
 - `parents`: Print currently selected version.
 - `packages`: Add `--version` flag to print currently used versions.
+- `packages`: Add `--targets` flag to print targets used in the corresponding manifest.
 
 ### Changed
 - `update`: Clean up alignment of manual resolution output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Print dependency updates executed.
 - Enable updating of individual dependencies (and recursive dependencies if desired).
 - Add support for glob in manifest source files.
+- `parents`: Print currently selected version.
 
 ### Changed
 - `update`: Clean up alignment of manual resolution output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Enable updating of individual dependencies (and recursive dependencies if desired).
 - Add support for glob in manifest source files.
 - `parents`: Print currently selected version.
+- `packages`: Add `--version` flag to print currently used versions.
 
 ### Changed
 - `update`: Clean up alignment of manual resolution output.

--- a/src/cmd/packages.rs
+++ b/src/cmd/packages.rs
@@ -3,10 +3,13 @@
 
 //! The `packages` subcommand.
 
+use std::io::Write;
+
 use clap::{Arg, ArgAction, ArgMatches, Command};
+use tabwriter::TabWriter;
 
 use crate::error::*;
-use crate::sess::Session;
+use crate::sess::{DependencySource, Session};
 
 /// Assemble the `packages` subcommand.
 pub fn new() -> Command {
@@ -27,12 +30,23 @@ pub fn new() -> Command {
             .help("Do not group packages by topological rank")
             .long_help("Do not group packages by topological rank. If the `--graph` option is specified, print multiple lines per package, one for each dependency.")
         )
+        .arg(Arg::new("version")
+            .long("version")
+            .num_args(0)
+            .action(ArgAction::SetTrue)
+            .help("Print the version of each package")
+            .long_help("Print the version of each package. Implies --flat. More detailed information is available per dependency using the `parents` subcommand.")
+    )
 }
 
 /// Execute the `packages` subcommand.
 pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
     let graph = matches.get_flag("graph");
     let flat = matches.get_flag("flat");
+    let version = matches.get_flag("version");
+    if graph && version {
+        return Err(Error::new("cannot specify both --graph and --version"));
+    }
     if graph {
         for (&pkg, deps) in sess.graph().iter() {
             let pkg_name = sess.dependency_name(pkg);
@@ -56,9 +70,29 @@ pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
             }
         }
     } else {
+        let mut version_str = String::from("");
         for pkgs in sess.packages().iter() {
             let pkg_names = pkgs.iter().map(|&id| sess.dependency_name(id));
-            if flat {
+            let pkg_sources = pkgs.iter().map(|&id| sess.dependency(id));
+            if version {
+                for pkg_source in pkg_sources {
+                    version_str.push_str(&format!(
+                        "{}:\t{}\tat {}\t{}\n",
+                        pkg_source.name,
+                        match pkg_source.version {
+                            Some(ref v) => format!("v{}", v),
+                            None => "".to_string(),
+                        },
+                        pkg_source.source,
+                        match pkg_source.source {
+                            DependencySource::Path { .. } => " as path".to_string(),
+                            DependencySource::Git(_) =>
+                                format!(" with hash {}", pkg_source.version()),
+                            _ => "".to_string(),
+                        }
+                    ));
+                }
+            } else if flat {
                 // Print one line per package.
                 for pkg_name in pkg_names {
                     println!("{}", pkg_name);
@@ -74,6 +108,12 @@ pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
                 }
                 println!();
             }
+        }
+        if version {
+            let mut tw = TabWriter::new(vec![]);
+            write!(&mut tw, "{}", version_str).unwrap();
+            tw.flush().unwrap();
+            print!("{}", String::from_utf8(tw.into_inner().unwrap()).unwrap());
         }
     }
     Ok(())

--- a/src/cmd/packages.rs
+++ b/src/cmd/packages.rs
@@ -48,27 +48,32 @@ pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
         return Err(Error::new("cannot specify both --graph and --version"));
     }
     if graph {
+        let mut graph_str = String::from("");
         for (&pkg, deps) in sess.graph().iter() {
             let pkg_name = sess.dependency_name(pkg);
             let dep_names = deps.iter().map(|&id| sess.dependency_name(id));
             if flat {
                 // Print one line per dependency.
                 for dep_name in dep_names {
-                    println!("{}\t{}", pkg_name, dep_name);
+                    graph_str.push_str(&format!("{}\t{}\n", pkg_name, dep_name));
                 }
             } else {
                 // Print all dependencies on one line.
-                print!("{}\t", pkg_name);
+                graph_str.push_str(&format!("{}\t", pkg_name));
                 for (i, dep_name) in dep_names.enumerate() {
                     if i > 0 {
-                        print!(" {}", dep_name);
+                        graph_str.push_str(&format!(" {}", dep_name));
                     } else {
-                        print!("{}", dep_name);
+                        graph_str.push_str(dep_name);
                     }
                 }
-                println!();
+                graph_str.push('\n');
             }
         }
+        let mut tw = TabWriter::new(vec![]);
+        write!(&mut tw, "{}", graph_str).unwrap();
+        tw.flush().unwrap();
+        print!("{}", String::from_utf8(tw.into_inner().unwrap()).unwrap());
     } else {
         let mut version_str = String::from("");
         for pkgs in sess.packages().iter() {

--- a/src/cmd/parents.rs
+++ b/src/cmd/parents.rs
@@ -29,7 +29,7 @@ pub fn new() -> Command {
 /// Execute the `parents` subcommand.
 pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
     let dep = &matches.get_one::<String>("name").unwrap().to_lowercase();
-    sess.dependency_with_name(dep)?;
+    let mydep = sess.dependency_with_name(dep)?;
     let rt = Runtime::new()?;
     let io = SessionIo::new(sess);
 
@@ -114,6 +114,21 @@ pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
         tw.flush().unwrap();
         print!("{}", String::from_utf8(tw.into_inner().unwrap()).unwrap());
     }
+
+    println!(
+        "{} used version: {} at {}{}",
+        sess.dependency(mydep).name,
+        match sess.dependency(mydep).version.clone() {
+            Some(ver) => ver.to_string(),
+            None => "".to_string(),
+        },
+        sess.dependency(mydep).source,
+        match sess.dependency(mydep).source {
+            DependencySource::Path { .. } => " as path".to_string(),
+            DependencySource::Git(_) => format!(" with hash {}", sess.dependency(mydep).version()),
+            _ => "".to_string(),
+        }
+    );
 
     if sess.config.overrides.contains_key(dep) {
         warnln!(

--- a/src/src.rs
+++ b/src/src.rs
@@ -268,6 +268,20 @@ impl<'ctx> SourceGroup<'ctx> {
         }
         flush_files(&mut files, into);
     }
+
+    /// Get available targets in sourcegroup.
+    pub fn get_avail_targets(&self) -> IndexSet<String> {
+        let mut targets = self.target.get_avail();
+        for file in &self.files {
+            match file {
+                SourceFile::File(_) => {}
+                SourceFile::Group(group) => {
+                    targets.extend(group.get_avail_targets());
+                }
+            }
+        }
+        targets
+    }
 }
 
 /// A source file.

--- a/src/target.rs
+++ b/src/target.rs
@@ -122,6 +122,18 @@ impl TargetSpec {
     pub fn is_wildcard(&self) -> bool {
         matches!(*self, TargetSpec::Wildcard)
     }
+
+    /// Get list of available targets.
+    pub fn get_avail(&self) -> IndexSet<String> {
+        match *self {
+            TargetSpec::Wildcard => IndexSet::new(),
+            TargetSpec::Name(ref name) => IndexSet::from([name.clone()]),
+            TargetSpec::All(ref specs) | TargetSpec::Any(ref specs) => {
+                specs.iter().flat_map(TargetSpec::get_avail).collect()
+            }
+            TargetSpec::Not(ref spec) => spec.get_avail(),
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]


### PR DESCRIPTION
- `parents`: Print currently selected version.
- `packages`: Add `--version` flag to print currently used versions.
- `packages`: Add `--targets` flag to print targets used in the corresponding manifest.
- `packages --graph`: Clean up alignment of output.