### PR TITLE
Add support for verilog/vhdl files with custom file endings

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,11 @@ sources:
       - src/core/alu.sv
       - src/core/top.sv
 
+  # Source files can have custom fileendings
+  - sv: vendor/encrypted_sv_src.svp
+  - v: vendor/encrypted_v_src.vp
+  - vhd: vendor/encrypted_vhd_src.e
+
 # A list of include directories which should implicitly be added to source
 # file groups of packages that have the current package as a dependency.
 # Optional.

--- a/src/cmd/fusesoc.rs
+++ b/src/cmd/fusesoc.rs
@@ -632,7 +632,7 @@ fn get_fileset_files(file_pkg: &SourceGroup, root_dir: PathBuf) -> Vec<FuseFileT
         .files
         .iter()
         .filter_map(|src_file| match src_file {
-            SourceFile::File(intern_file) => Some(
+            SourceFile::File(intern_file, _) => Some(
                 match intern_file.extension().and_then(std::ffi::OsStr::to_str) {
                     Some("vhd") | Some("vhdl") => FuseFileType::IndexMap(IndexMap::from([(
                         intern_file

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -15,7 +15,7 @@ use tokio::runtime::Runtime;
 
 use crate::error::*;
 use crate::sess::{Session, SessionIo};
-use crate::src::{SourceFile, SourceGroup};
+use crate::src::{SourceFile, SourceGroup, SourceType};
 use crate::target::{TargetSet, TargetSpec};
 
 /// Assemble the `script` subcommand.
@@ -447,12 +447,6 @@ where
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-enum SourceType {
-    Verilog,
-    Vhdl,
-}
-
 fn relativize_path(path: &std::path::Path, root: &std::path::Path) -> String {
     if path.starts_with(root) {
         format!(
@@ -547,7 +541,7 @@ fn emit_template(
         all_files
             .into_iter()
             .filter_map(|file| match file {
-                SourceFile::File(p) => Some(p.to_path_buf()),
+                SourceFile::File(p, _) => Some(p.to_path_buf()),
                 _ => None,
             })
             .collect()
@@ -561,7 +555,7 @@ fn emit_template(
         separate_files_in_group(
             src,
             |f| match f {
-                SourceFile::File(p) => match p.extension().and_then(std::ffi::OsStr::to_str) {
+                SourceFile::File(p, _) => match p.extension().and_then(std::ffi::OsStr::to_str) {
                     Some("sv") | Some("v") | Some("vp") => Some(SourceType::Verilog),
                     Some("vhd") | Some("vhdl") => Some(SourceType::Vhdl),
                     _ => None,
@@ -594,7 +588,7 @@ fn emit_template(
                     files: files
                         .iter()
                         .map(|f| match f {
-                            SourceFile::File(p) => p.to_path_buf(),
+                            SourceFile::File(p, _) => p.to_path_buf(),
                             SourceFile::Group(_) => unreachable!(),
                         })
                         .collect(),

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -555,10 +555,14 @@ fn emit_template(
         separate_files_in_group(
             src,
             |f| match f {
-                SourceFile::File(p, _) => match p.extension().and_then(std::ffi::OsStr::to_str) {
-                    Some("sv") | Some("v") | Some("vp") => Some(SourceType::Verilog),
-                    Some("vhd") | Some("vhdl") => Some(SourceType::Vhdl),
-                    _ => None,
+                SourceFile::File(p, fmt) => match fmt {
+                    Some(SourceType::Verilog) => Some(SourceType::Verilog),
+                    Some(SourceType::Vhdl) => Some(SourceType::Vhdl),
+                    _ => match p.extension().and_then(std::ffi::OsStr::to_str) {
+                        Some("sv") | Some("v") | Some("vp") => Some(SourceType::Verilog),
+                        Some("vhd") | Some("vhdl") => Some(SourceType::Vhdl),
+                        _ => None,
+                    },
                 },
                 _ => None,
             },

--- a/src/cmd/vendor.rs
+++ b/src/cmd/vendor.rs
@@ -766,7 +766,8 @@ pub fn copy_recursively(
                     ),
                     cause,
                 )
-            })?)?;
+            })?)?
+            .file_type();
         if filetype.is_dir() {
             copy_recursively(
                 entry.path(),

--- a/src/sess.rs
+++ b/src/sess.rs
@@ -401,6 +401,17 @@ impl<'sess, 'ctx: 'sess> Session<'ctx> {
             .iter()
             .map(|file| match *file {
                 config::SourceFile::File(ref path) => (path as &Path).into(),
+                config::SourceFile::SvFile(ref path) => crate::src::SourceFile::File(
+                    path as &Path,
+                    &Some(crate::src::SourceType::Verilog),
+                ),
+                config::SourceFile::VerilogFile(ref path) => crate::src::SourceFile::File(
+                    path as &Path,
+                    &Some(crate::src::SourceType::Verilog),
+                ),
+                config::SourceFile::VhdlFile(ref path) => {
+                    crate::src::SourceFile::File(path as &Path, &Some(crate::src::SourceType::Vhdl))
+                }
                 config::SourceFile::Group(ref group) => self
                     .load_sources(
                         group.as_ref(),

--- a/src/src.rs
+++ b/src/src.rs
@@ -295,7 +295,14 @@ pub enum SourceFile<'ctx> {
 impl<'ctx> fmt::Debug for SourceFile<'ctx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            SourceFile::File(path, _) => fmt::Debug::fmt(path, f),
+            SourceFile::File(path, ty) => {
+                fmt::Debug::fmt(path, f)?;
+                if let Some(t) = ty {
+                    write!(f, " as {:?}", t)
+                } else {
+                    write!(f, " as <unknown>")
+                }
+            }
             SourceFile::Group(ref srcs) => fmt::Debug::fmt(srcs, f),
         }
     }

--- a/src/src.rs
+++ b/src/src.rs
@@ -232,7 +232,7 @@ impl<'ctx> SourceGroup<'ctx> {
         };
         for file in subfiles {
             match file {
-                SourceFile::File(_) => {
+                SourceFile::File(_, _) => {
                     files.push(file);
                 }
                 SourceFile::Group(grp) => {
@@ -270,13 +270,24 @@ impl<'ctx> SourceGroup<'ctx> {
     }
 }
 
+/// File types for a source file.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum SourceType {
+    /// A Verilog file.
+    Verilog,
+    // /// A SystemVerilog file.
+    // SystemVerilog,
+    /// A VHDL file.
+    Vhdl,
+}
+
 /// A source file.
 ///
 /// This can either be an individual file, or a subgroup of files.
 #[derive(Clone)]
 pub enum SourceFile<'ctx> {
     /// A file.
-    File(&'ctx Path),
+    File(&'ctx Path, &'ctx Option<SourceType>),
     /// A group of files.
     Group(Box<SourceGroup<'ctx>>),
 }
@@ -284,7 +295,7 @@ pub enum SourceFile<'ctx> {
 impl<'ctx> fmt::Debug for SourceFile<'ctx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            SourceFile::File(path) => fmt::Debug::fmt(path, f),
+            SourceFile::File(path, _) => fmt::Debug::fmt(path, f),
             SourceFile::Group(ref srcs) => fmt::Debug::fmt(srcs, f),
         }
     }
@@ -298,7 +309,7 @@ impl<'ctx> From<SourceGroup<'ctx>> for SourceFile<'ctx> {
 
 impl<'ctx> From<&'ctx Path> for SourceFile<'ctx> {
     fn from(path: &'ctx Path) -> SourceFile<'ctx> {
-        SourceFile::File(path)
+        SourceFile::File(path, &None)
     }
 }
 
@@ -309,7 +320,7 @@ impl<'ctx> Serialize for SourceFile<'ctx> {
         S: Serializer,
     {
         match *self {
-            SourceFile::File(path) => path.serialize(serializer),
+            SourceFile::File(path, _) => path.serialize(serializer),
             SourceFile::Group(ref group) => group.serialize(serializer),
         }
     }


### PR DESCRIPTION
This PR adds support for custom file endings of vhdl, verilog, or systemverilog files. This is relevant for scripts generated directly for custom tools, e.g., to import encrypted files that have endings such as `.svp`, `.vp`, or `.e` (or anything else you could think of). Custom file endings can now be allocated a file type as follows:

```yaml
  # Source files can have custom fileendings
  - sv: vendor/encrypted_sv_src.svp
  - v: vendor/encrypted_v_src.vp
  - vhd: vendor/encrypted_vhd_src.e
```