### PR TITLE
Multi-Arch Releases

### DIFF
--- a/.github/scripts/gen_dockerfile.sh
+++ b/.github/scripts/gen_dockerfile.sh
@@ -48,7 +48,7 @@ if [[ $(echo $full_tgtname | cut -d ':' -f 1) == "redhat"* ]]; then
 fi
 echo >> $filename
 echo 'ENV RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo' >> $filename
-echo 'ENV PATH $CARGO_HOME/bin:$PATH' >> $filename
+echo 'ENV PATH=$CARGO_HOME/bin:$PATH' >> $filename
 echo >> $filename
 echo 'RUN mkdir -p "$CARGO_HOME" && mkdir -p "$RUSTUP_HOME" && \' >> $filename
 echo '    curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable && \' >> $filename

--- a/.github/scripts/package.sh
+++ b/.github/scripts/package.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# This script expects two optional arguments:
+# 1. The target architecture (e.g., x86_64, aarch64)
+# 2. The target OS (e.g., linux, windows, macos)
+
 if [[ "$GITHUB_REF" =~ ^refs/tags/v.*$ ]]; then
     pkgver="$(echo $GITHUB_REF | sed -n 's/^refs\/tags\/v//p')"
 else
@@ -10,18 +14,18 @@ if [ -z "$pkgver" ]; then
     pkgver="latest"
 fi
 
-if [ -z "$1" ] && [ -z "$2" ]; then # no arguments
+if [ -z "$2" ] && [ -z "$1" ]; then # no arguments
     release_dir="target/release"
     tar_suffix=""
     tar_prefix="-x86_64"
-elif [ -n "$1" ] && [ -n "$2" ]; then # both arguments
-    release_dir="target/$2/$1/release"
-    tar_suffix="-$1"
-    tar_prefix="-$2"
 elif [ -n "$1" ] && [ -z "$2" ]; then # only first argument
     release_dir="target/$1/release"
-    tar_suffix="-$1"
-    tar_prefix="-x86_64"
+    tar_suffix=""
+    tar_prefix="-$1"
+elif [ -n "$2" ] && [ -n "$1" ]; then # both arguments
+    release_dir="target/$1/$2/release"
+    tar_suffix="-$2"
+    tar_prefix="-$1"
 fi
 
 # WIESEP: Change amd64 to x86_64 to keep release names compatible with previous releases

--- a/.github/scripts/package.sh
+++ b/.github/scripts/package.sh
@@ -1,20 +1,35 @@
 #!/usr/bin/env bash
 
 if [[ "$GITHUB_REF" =~ ^refs/tags/v.*$ ]]; then
-    readonly pkgver="$(echo $GITHUB_REF | sed -n 's/^refs\/tags\/v//p')"
+    pkgver="$(echo $GITHUB_REF | sed -n 's/^refs\/tags\/v//p')"
 else
-    readonly pkgver="$(echo $GITHUB_REF | sed -n 's/^refs\/tags\///p')"
+    pkgver="$(echo $GITHUB_REF | sed -n 's/^refs\/tags\///p')"
 fi
 
-if [ -z "$1" ]; then
-    readonly release_dir="target/release"
-    readonly tar_suffix=""
-else
-    readonly release_dir="target/$1/release"
-    readonly tar_suffix="-$1"
+if [ -z "$pkgver" ]; then
+    pkgver="latest"
 fi
 
-tar -czf "bender-$pkgver-x86_64-linux-gnu$tar_suffix.tar.gz" \
+if [ -z "$1" ] && [ -z "$2" ]; then # no arguments
+    release_dir="target/release"
+    tar_suffix=""
+    tar_prefix="-x86_64"
+elif [ -n "$1" ] && [ -n "$2" ]; then # both arguments
+    release_dir="target/$2/$1/release"
+    tar_suffix="-$1"
+    tar_prefix="-$2"
+elif [ -n "$1" ] && [ -z "$2" ]; then # only first argument
+    release_dir="target/$1/release"
+    tar_suffix="-$1"
+    tar_prefix="-x86_64"
+fi
+
+# WIESEP: Change amd64 to x86_64 to keep release names compatible with previous releases
+if [ "$tar_prefix" == "-amd64" ]; then
+    tar_prefix="-x86_64"
+fi
+
+tar -czf "bender-$pkgver$tar_prefix-linux-gnu$tar_suffix.tar.gz" \
         -C "./$release_dir" \
         --owner=0 --group=0 \
         bender

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,7 +75,7 @@ jobs:
         run: |
           export tgtname=$(echo ${{ matrix.os }} | tr -d ':')
           export platform=$(echo ${{ matrix.platform }} | awk -F'/' '{print $NF}')
-          .github/scripts/package.sh $tgtname $platform;
+          .github/scripts/package.sh $platform $tgtname;
         shell: bash
       - name: Upload Release Asset
         uses: softprops/action-gh-release@v1
@@ -120,7 +120,7 @@ jobs:
         run: |
           export tgtname=$(echo ${{ matrix.os }} | tr -d ':')
           export platform=$(echo ${{ matrix.platform }} | awk -F'/' '{print $NF}')
-          .github/scripts/package.sh $tgtname $platform;
+          .github/scripts/package.sh $platform $tgtname;
         shell: bash
       - name: Upload Release Asset
         uses: softprops/action-gh-release@v1
@@ -129,7 +129,52 @@ jobs:
           files: bender-*.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  release-gnu:
+  release-gnu_amd64:
+    runs-on: ubuntu-24.04-arm
+    # Use container that supports old GLIBC versions and (hopefully) many linux OSs
+    # container: quay.io/pypa/manylinux2014_aarch64
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Dockerfile
+        run: |
+          touch Dockerfile
+          echo "FROM quay.io/pypa/manylinux2014_aarch64" >> Dockerfile
+          echo "RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo" >> Dockerfile
+          echo "RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo" >> Dockerfile
+          echo "RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo" >> Dockerfile
+
+          echo "RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*" >> Dockerfile
+          echo "RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*" >> Dockerfile
+          echo "RUN yum group install "Development Tools" -y && yum clean all" >> Dockerfile
+          echo 'ENV RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo' >> Dockerfile
+          echo 'ENV PATH=$CARGO_HOME/bin:$PATH' >> Dockerfile
+          echo >> Dockerfile
+          echo 'RUN mkdir -p "$CARGO_HOME" && mkdir -p "$RUSTUP_HOME" && \' >> Dockerfile
+          echo '    curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable && \' >> Dockerfile
+          echo '    chmod -R a=rwX $CARGO_HOME' >> Dockerfile
+          echo >> Dockerfile
+          echo 'WORKDIR /source' >> Dockerfile
+      - name: OS build
+        run: |
+          docker build ./ -t manylinux-amd64 --platform linux/amd64
+          docker run \
+            -t --rm \
+            -v "$GITHUB_WORKSPACE:/source" \
+            -v "$GITHUB_WORKSPACE/target/amd64:/source/target" \
+            --platform linux/amd64 \
+            manylinux-amd64 \
+            cargo build --release;
+      - name: GNU Create Package
+        run: .github/scripts/package.sh amd64
+        shell: bash
+      - name: Upload Release Asset
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          files: bender-*.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  release-gnu_arm64:
     runs-on: ubuntu-latest
     # Use container that supports old GLIBC versions and (hopefully) many linux OSs
     # container: quay.io/pypa/manylinux2014_x86_64
@@ -147,7 +192,7 @@ jobs:
           echo "RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*" >> Dockerfile
           echo "RUN yum group install "Development Tools" -y && yum clean all" >> Dockerfile
           echo 'ENV RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo' >> Dockerfile
-          echo 'ENV PATH $CARGO_HOME/bin:$PATH' >> Dockerfile
+          echo 'ENV PATH=$CARGO_HOME/bin:$PATH' >> Dockerfile
           echo >> Dockerfile
           echo 'RUN mkdir -p "$CARGO_HOME" && mkdir -p "$RUSTUP_HOME" && \' >> Dockerfile
           echo '    curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable && \' >> Dockerfile
@@ -156,15 +201,16 @@ jobs:
           echo 'WORKDIR /source' >> Dockerfile
       - name: OS build
         run: |
-          docker build ./ -t manylinux
+          docker build ./ -t manylinux-arm64 --platform linux/arm64
           docker run \
             -t --rm \
             -v "$GITHUB_WORKSPACE:/source" \
-            -v "$GITHUB_WORKSPACE/target:/source/target" \
-            manylinux \
+            -v "$GITHUB_WORKSPACE/target/arm64:/source/target" \
+            --platform linux/arm64 \
+            manylinux-arm64 \
             cargo build --release;
       - name: GNU Create Package
-        run: .github/scripts/package.sh
+        run: .github/scripts/package.sh arm64
         shell: bash
       - name: Upload Release Asset
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  release:
+  release_amd64:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -51,25 +51,76 @@ jobs:
           - almalinux:9.3
           - almalinux:9.4
           - almalinux:9.5
+        platform:
+          - linux/amd64
     steps:
       - uses: actions/checkout@v4
       - name: OS Build
         run: |
           export full_tgtname=${{ matrix.os }}
           export tgtname=$(echo ${{ matrix.os }} | tr -d ':')
+          export full_platform=${{ matrix.platform }}
+          export platform=$(echo ${{ matrix.platform }} | awk -F'/' '{print $NF}')
           .github/scripts/gen_dockerfile.sh
-          docker build ./ -t $tgtname
+          docker build ./ -t $tgtname-$platform --platform $full_platform
           docker run \
             -t --rm \
             -v "$GITHUB_WORKSPACE:/source" \
-            -v "$GITHUB_WORKSPACE/target/$tgtname:/source/target" \
-            $tgtname \
+            -v "$GITHUB_WORKSPACE/target/$platform/$tgtname:/source/target" \
+            --platform $full_platform \
+            $tgtname-$platform \
             cargo build --release;
         shell: bash
       - name: OS Create Package
         run: |
-          tgtname=$(echo ${{ matrix.os }} | tr -d ':')
-          .github/scripts/package.sh $tgtname;
+          export tgtname=$(echo ${{ matrix.os }} | tr -d ':')
+          export platform=$(echo ${{ matrix.platform }} | awk -F'/' '{print $NF}')
+          .github/scripts/package.sh $tgtname $platform;
+        shell: bash
+      - name: Upload Release Asset
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          files: bender-*.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  release_arm64:
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        rust:
+          - stable
+        os:
+          - ubuntu:18.04
+          - ubuntu:20.04
+          - ubuntu:22.04
+          - ubuntu:24.04
+        platform:
+          - linux/arm64
+    steps:
+      - uses: actions/checkout@v4
+      - name: OS Build
+        run: |
+          export full_tgtname=${{ matrix.os }}
+          export tgtname=$(echo ${{ matrix.os }} | tr -d ':')
+          export full_platform=${{ matrix.platform }}
+          export platform=$(echo ${{ matrix.platform }} | awk -F'/' '{print $NF}')
+          .github/scripts/gen_dockerfile.sh
+          docker build ./ -t $tgtname-$platform --platform $full_platform
+          docker run \
+            -t --rm \
+            -v "$GITHUB_WORKSPACE:/source" \
+            -v "$GITHUB_WORKSPACE/target/$platform/$tgtname:/source/target" \
+            --platform $full_platform \
+            $tgtname-$platform \
+            cargo build --release;
+        shell: bash
+      - name: OS Create Package
+        run: |
+          export tgtname=$(echo ${{ matrix.os }} | tr -d ':')
+          export platform=$(echo ${{ matrix.platform }} | awk -F'/' '{print $NF}')
+          .github/scripts/package.sh $tgtname $platform;
         shell: bash
       - name: Upload Release Asset
         uses: softprops/action-gh-release@v1
@@ -80,8 +131,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   release-gnu:
     runs-on: ubuntu-latest
-    strategy: 
-      fail-fast: false
     # Use container that supports old GLIBC versions and (hopefully) many linux OSs
     # container: quay.io/pypa/manylinux2014_x86_64
     steps:
@@ -126,8 +175,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   release-macos:
     runs-on: macos-latest
-    strategy:
-      fail-fast: true
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - `script`: Fix flist-plus incdir template.
 
 ### Added
+- Add ARM64 binaries for releases
 - `update`: Update repositories in checkout dir if conditions match:
   - Folder is a git repository
   - Git state is clean


### PR DESCRIPTION
This PR adds support for building multi-arch releases. See https://github.com/Xeratec/bender/releases/tag/v0.28.3-rc1 for an example.

## Added
- New `release_arm64` build stage

## Changes
- Renamed `release` stage to `release_amd64`

## Fixed
- Fixed `ENV` warning in Dockerfile

## Note
- During the build, the release files are placed in `target/<architecture>/<platform>` (e.g. `target/arm64/ubuntu22.04`)
- To keep the release names compatible with earlier releases, `amd64` is replaced with `x86_64`