### PR TITLE
Added conditional compilation for symlink removal in cli and clone

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -323,23 +323,23 @@ pub fn main() -> Result<()> {
     }
 }
 
-#[cfg(target_family = "unix")]
-fn symlink_dir(p: &Path, q: &Path) -> Result<()> {
+#[cfg(unix)]
+pub fn symlink_dir(p: &Path, q: &Path) -> Result<()> {
     Ok(std::os::unix::fs::symlink(p, q)?)
 }
 
-#[cfg(target_os = "windows")]
-fn symlink_dir(p: &Path, q: &Path) -> Result<()> {
+#[cfg(windows)]
+pub fn symlink_dir(p: &Path, q: &Path) -> Result<()> {
     Ok(std::os::windows::fs::symlink_dir(p, q)?)
 }
 
-#[cfg(target_family = "unix")]
-fn remove_symlink_dir(path: &Path) -> Result<()> {
+#[cfg(unix)]
+pub fn remove_symlink_dir(path: &Path) -> Result<()> {
     Ok(std::fs::remove_file(path)?)
 }
 
-#[cfg(target_os = "windows")]
-fn remove_symlink_dir(path: &Path) -> Result<()> {
+#[cfg(windows)]
+pub fn remove_symlink_dir(path: &Path) -> Result<()> {
     Ok(std::fs::remove_dir(path)?)
 }
 

--- a/src/cmd/clone.rs
+++ b/src/cmd/clone.rs
@@ -10,6 +10,7 @@ use clap::Args;
 use indexmap::IndexMap;
 use tokio::runtime::Runtime;
 
+use crate::cli::{remove_symlink_dir, symlink_dir};
 use crate::config;
 use crate::config::{Locked, LockedSource};
 use crate::diagnostic::Warnings;
@@ -312,30 +313,6 @@ pub fn run(sess: &Session, path: &Path, args: &CloneArgs) -> Result<()> {
     }
 
     Ok(())
-}
-
-/// Create a directory symlink.
-#[cfg(unix)]
-pub fn symlink_dir(p: &Path, q: &Path) -> Result<()> {
-    Ok(std::os::unix::fs::symlink(p, q)?)
-}
-
-/// Create a directory symlink.
-#[cfg(windows)]
-pub fn symlink_dir(p: &Path, q: &Path) -> Result<()> {
-    Ok(std::os::windows::fs::symlink_dir(p, q)?)
-}
-
-/// Remove a directory symlink.
-#[cfg(unix)]
-pub fn remove_symlink_dir(path: &Path) -> Result<()> {
-    Ok(std::fs::remove_file(path)?)
-}
-
-/// Remove a directory symlink.
-#[cfg(windows)]
-pub fn remove_symlink_dir(path: &Path) -> Result<()> {
-    Ok(std::fs::remove_dir(path)?)
 }
 
 /// A helper function to recursively get all path subdependencies of a dependency.

--- a/src/cmd/snapshot.rs
+++ b/src/cmd/snapshot.rs
@@ -10,7 +10,8 @@ use clap::Args;
 use indexmap::IndexMap;
 use tokio::runtime::Runtime;
 
-use crate::cmd::clone::{get_path_subdeps, symlink_dir};
+use crate::cli::symlink_dir;
+use crate::cmd::clone::get_path_subdeps;
 use crate::config::{Dependency, Locked, LockedSource};
 use crate::diagnostic::Warnings;
 use crate::error::*;


### PR DESCRIPTION
Removal of symlinks is now handled differently for Unix and Windows:
- Unix: Keeps `std::fs::remove_file()`
- Windows: Uses `std::fs::remove_dir()`instead. 
See #251 for issue