### PR TITLE
fix(git): Disable interactive git prompts

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -79,6 +79,11 @@ impl<'ctx> Git<'ctx> {
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
 
+        // Disable interactive terminal prompts.
+        // This ensures git fails immediately with a specific error message
+        // instead of hanging indefinitely if auth is missing.
+        cmd.env("GIT_TERMINAL_PROMPT", "0");
+
         // Spawn the child process
         let mut child = cmd.spawn().map_err(|cause| {
             if cause


### PR DESCRIPTION
If authentication is not set up correctly in the `git` executable, it will show a git authentication prompt. However, the prompt interfers with the progress bars, which consume it (because rendering progress bars requires clearing the last couple of lines and re-rendering them from time to time). This change essentially disables any kind of manual authentication and just returns an error as fast as possible