### PR TITLE
feat: filter export_include_dirs of excluded packages by default

### DIFF
--- a/src/cmd/fusesoc.rs
+++ b/src/cmd/fusesoc.rs
@@ -299,7 +299,7 @@ pub fn run(sess: &Session, args: &FusesocArgs) -> Result<()> {
     // Generate new `.core` files
     for pkg in generate_files.keys() {
         let src_packages = &srcs
-            .filter_packages(&vec![pkg.to_string()].into_iter().collect())
+            .filter_packages(&vec![pkg.to_string()].into_iter().collect(), false)
             .unwrap_or_default()
             .flatten();
 
@@ -481,7 +481,7 @@ fn get_fuse_depend_string(
     version_string: Option<semver::Version>,
 ) -> String {
     let src_packages = srcs
-        .filter_packages(&vec![pkg.to_string()].into_iter().collect())
+        .filter_packages(&vec![pkg.to_string()].into_iter().collect(), false)
         .unwrap_or_default()
         .flatten();
 

--- a/src/cmd/packages.rs
+++ b/src/cmd/packages.rs
@@ -57,7 +57,7 @@ pub fn run(sess: &Session, args: &PackagesArgs) -> Result<()> {
                 target_str.push_str(&format!(
                     "{}:\t{:?}\n",
                     pkg_name,
-                    srcs.filter_packages(&IndexSet::from([pkg_name.into()]))
+                    srcs.filter_packages(&IndexSet::from([pkg_name.into()]), false)
                         .unwrap_or_default()
                         .get_avail_targets()
                 ));
@@ -66,7 +66,7 @@ pub fn run(sess: &Session, args: &PackagesArgs) -> Result<()> {
         target_str.push_str(&format!(
             "{}:\t{:?}\n",
             &sess.manifest.package.name,
-            srcs.filter_packages(&IndexSet::from([sess.manifest.package.name.clone()]))
+            srcs.filter_packages(&IndexSet::from([sess.manifest.package.name.clone()]), false)
                 .unwrap_or_default()
                 .get_avail_targets()
         ));

--- a/src/cmd/pickle.rs
+++ b/src/cmd/pickle.rs
@@ -44,6 +44,10 @@ pub struct PickleArgs {
     #[arg(long)]
     pub exclude: Vec<String>,
 
+    /// Keep export include directories from excluded packages
+    #[arg(long)]
+    pub keep_excluded_incdirs: bool,
+
     /// Exclude all dependencies, i.e. only top level or specified package(s)
     #[arg(long)]
     pub no_deps: bool,
@@ -117,7 +121,7 @@ pub fn run(sess: &Session, args: PickleArgs) -> Result<()> {
     let srcs = srcs
         .filter_targets(&targets)
         .unwrap_or_default()
-        .filter_packages(&packages)
+        .filter_packages(&packages, args.keep_excluded_incdirs)
         .unwrap_or_default();
 
     // Flatten and validate the sources.

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -52,6 +52,10 @@ pub struct ScriptArgs {
     #[arg(short, long, action = ArgAction::Append, global = true, help_heading = "General Script Options")]
     pub exclude: Vec<String>,
 
+    /// Keep export include directories from excluded packages
+    #[arg(long, global = true, help_heading = "General Script Options")]
+    pub keep_excluded_incdirs: bool,
+
     /// Add the `rtl` target to any fileset without a target specification
     #[arg(long, global = true, help_heading = "General Script Options")]
     pub assume_rtl: bool,
@@ -297,7 +301,9 @@ pub fn run(sess: &Session, args: &ScriptArgs) -> Result<()> {
 
     srcs = srcs.filter_targets(&targets).unwrap_or_default();
 
-    srcs = srcs.filter_packages(&packages).unwrap_or_default();
+    srcs = srcs
+        .filter_packages(&packages, args.keep_excluded_incdirs)
+        .unwrap_or_default();
 
     // Flatten and validate the sources.
     let srcs = srcs

--- a/src/cmd/sources.rs
+++ b/src/cmd/sources.rs
@@ -43,6 +43,10 @@ pub struct SourcesArgs {
     #[arg(short, long, action = ArgAction::Append)]
     pub exclude: Vec<String>,
 
+    /// Keep export include directories from excluded packages
+    #[arg(long)]
+    pub keep_excluded_incdirs: bool,
+
     /// Add the `rtl` target to any fileset without a target specification
     #[arg(long)]
     pub assume_rtl: bool,
@@ -119,7 +123,9 @@ pub fn run(sess: &Session, args: &SourcesArgs) -> Result<()> {
 
     srcs = srcs.filter_targets(&targets).unwrap_or_default();
 
-    srcs = srcs.filter_packages(&packages).unwrap_or_default();
+    srcs = srcs
+        .filter_packages(&packages, args.keep_excluded_incdirs)
+        .unwrap_or_default();
 
     srcs = srcs.validate(&ValidationContext::default())?;
 

--- a/src/src.rs
+++ b/src/src.rs
@@ -269,7 +269,14 @@ impl<'ctx> SourceGroup<'ctx> {
     }
 
     /// Filter the sources, keeping only the ones that apply to the selected packages.
-    pub fn filter_packages(&self, packages: &IndexSet<String>) -> Option<SourceGroup<'ctx>> {
+    ///
+    /// If `keep_excluded_incdirs` is false, export include directories from packages
+    /// not in `packages` are removed. If true, all export include directories are kept.
+    pub fn filter_packages(
+        &self,
+        packages: &IndexSet<String>,
+        keep_excluded_incdirs: bool,
+    ) -> Option<SourceGroup<'ctx>> {
         let mut files = Vec::new();
 
         if self.package.is_none() || packages.contains(self.package.unwrap()) {
@@ -278,14 +285,22 @@ impl<'ctx> SourceGroup<'ctx> {
                 .iter()
                 .filter_map(|file| match *file {
                     SourceFile::Group(ref group) => group
-                        .filter_packages(packages)
+                        .filter_packages(packages, keep_excluded_incdirs)
                         .map(|g| SourceFile::Group(Box::new(g))),
                     ref other => Some(other.clone()),
                 })
                 .collect();
         }
 
-        let export_incdirs = self.export_incdirs.clone();
+        let export_incdirs = if keep_excluded_incdirs {
+            self.export_incdirs.clone()
+        } else {
+            self.export_incdirs
+                .iter()
+                .filter(|(pkg, _)| packages.contains(pkg.as_str()))
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect()
+        };
         Some(
             SourceGroup {
                 export_incdirs,


### PR DESCRIPTION
When excluding dependencies via `--exclude`, their export include directories were still included in the output. Now they are filtered out by default. A new `--keep-excluded-incdirs` flag is available on `script`, `sources`, and `pickle` commands to preserve the old behavior.