### PR TITLE
fix(paths): Resolve env vars before applying prefix to dependency paths

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1572,8 +1572,14 @@ impl PrefixPaths for PathBuf {
 
 impl PrefixPaths for String {
     fn prefix_paths(self, prefix: &Path) -> Result<Self> {
-        // env is resolved later, convert back to string here.
-        Ok(prefix.join(PathBuf::from(&self)).display().to_string())
+        // Resolve env vars first so absolute results bypass the prefix.
+        let substituted = env_string_from_string(&self)?;
+        let path = PathBuf::from(&substituted);
+        if path.is_absolute() {
+            Ok(substituted)
+        } else {
+            Ok(prefix.join(&path).display().to_string())
+        }
     }
 }
 


### PR DESCRIPTION
`PrefixPaths for String` joins the consuming Bender.yml's parent directory onto the raw template string before env vars are substituted, so a `${VAR}` that expands to an absolute path is treated as a relative segment and double-slashed (e.g. `<parent>//repo/...`). Direct absolute literals and relative env vars work; only absolute env-var expansions break.

This PR fixes the issue by:

- Substituting env vars in `PrefixPaths for String` before deciding whether to prefix.
- Skipping the prefix when the substituted result is already absolute; otherwise joining as before.

Fixes #302