### PR TITLE
Add git database locks and db_dir config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         # Linux runs the full Rust version matrix; Windows and macOS test stable only.
         os: [ubuntu-latest]
-        rust: [stable, beta, nightly, "1.87.0"]
+        rust: [stable, beta, nightly, "1.89.0"]
         include:
           - os: windows-latest
             rust: stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Added
 - Add new `crates/bender-slang` crate that integrates the vendored Slang parser via a Rust/C++ bridge.
 - Add new `pickle` command (behind feature `slang`) to parse and re-emit SystemVerilog sources.
+- Add cross-process filesystem locks around git database and checkout operations so concurrent `bender` invocations against the same dependency serialize safely.
+- Add `db_dir` config field to share bare-repo and lock storage across projects without relocating per-project checkouts; older Bender versions silently ignore the field and fall back to their per-project default.
 
 ## 0.31.0 - 2026-03-03
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,6 @@ dependencies = [
  "dirs",
  "dunce",
  "env_logger",
- "fs4",
  "futures",
  "glob",
  "indexmap",
@@ -581,16 +580,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "fs4"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
-dependencies = [
- "rustix",
- "windows-sys",
-]
 
 [[package]]
 name = "futures"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,7 @@ dependencies = [
  "dirs",
  "dunce",
  "env_logger",
+ "fs4",
  "futures",
  "glob",
  "indexmap",
@@ -580,6 +581,16 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fs4"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
+dependencies = [
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "futures"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ indicatif = "0.18.3"
 regex = "1.12.2"
 log = "0.4"
 env_logger = { version = "0.11", default-features = false, features = ["auto-color"] }
+fs4 = "1.1"
 
 [target.'cfg(windows)'.dependencies]
 dunce = "1.0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = "A dependency management tool for hardware projects."
 readme = "README.md"
 license = "Apache-2.0 OR MIT"
 edition = "2024"
-rust-version = "1.87.0"
+rust-version = "1.89.0"
 
 [workspace]
 members = ["crates/bender-slang"]
@@ -53,7 +53,6 @@ indicatif = "0.18.3"
 regex = "1.12.2"
 log = "0.4"
 env_logger = { version = "0.11", default-features = false, features = ["auto-color"] }
-fs4 = "1.1"
 
 [target.'cfg(windows)'.dependencies]
 dunce = "1.0.4"

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -27,6 +27,14 @@ The directory where Bender stores cloned and checked-out dependencies.
 - **Default:** `.bender` in the project root.
 - **Example:** `database: /var/cache/bender_dependencies`
 
+### `db_dir`
+Optional override for the directory that holds bare git repositories and their lock files (i.e. `<db_dir>/git/db/` and `<db_dir>/git/locks/`). When set, it takes precedence over `database` (whether explicitly configured or left at its default) for these two paths only; the working-tree checkouts continue to follow `database` (or [`workspace.checkout_dir`](./manifest.md) in the project manifest). This makes it possible to share the heavy git data across projects on a persistent runner without also relocating per-project checkouts. See [Continuous Integration › Sharing the Database](./workflow/ci.md#sharing-the-database-across-runs-and-projects) for the recommended setup.
+- **Config Key:** `db_dir`
+- **Default:** unset (falls back to `database`).
+- **Example:** `db_dir: /var/cache/bender_shared`
+
+> **Note:** Older Bender versions (pre-`db_dir`) silently ignore this field and fall back to their per-project default, so it is safe to ship in a shared configuration that mixed bender versions may read.
+
 ### `git`
 The command or path used to invoke Git.
 - **Config Key:** `git`

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -34,7 +34,7 @@ Optional override for the directory that holds bare git repositories and their l
 - **Default:** unset (falls back to `database`).
 - **Example:** `db_dir: /var/cache/bender_shared`
 
-> **Note:** Older Bender versions (pre-`db_dir`) silently ignore this field and fall back to their per-project default, so it is safe to ship in a shared configuration that mixed bender versions may read.
+> **Note:** Bender versions before 0.32 silently ignore this field and fall back to their per-project default, so it is safe to ship in a shared configuration that mixed bender versions may read.
 
 ### `git`
 The command or path used to invoke Git.

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -30,6 +30,7 @@ The directory where Bender stores cloned and checked-out dependencies.
 ### `db_dir`
 Optional override for the directory that holds bare git repositories and their lock files (i.e. `<db_dir>/git/db/` and `<db_dir>/git/locks/`). When set, it takes precedence over `database` (whether explicitly configured or left at its default) for these two paths only; the working-tree checkouts continue to follow `database` (or [`workspace.checkout_dir`](./manifest.md) in the project manifest). This makes it possible to share the heavy git data across projects on a persistent runner without also relocating per-project checkouts. See [Continuous Integration › Sharing the Database](./workflow/ci.md#sharing-the-database-across-runs-and-projects) for the recommended setup.
 - **Config Key:** `db_dir`
+- **Env Var:** `BENDER_DB_DIR` (used only when no configuration file sets `db_dir`; configuration files always take precedence).
 - **Default:** unset (falls back to `database`).
 - **Example:** `db_dir: /var/cache/bender_shared`
 

--- a/book/src/local.md
+++ b/book/src/local.md
@@ -42,7 +42,7 @@ database: my_deps_cache
 
 # Share only the bare git repos and lock files across projects, while
 # keeping per-project checkouts under each project's own .bender/.
-# Older Bender versions silently ignore this field.
+# Bender versions before 0.32 silently ignore this field.
 db_dir: /var/cache/bender_shared
 
 # Use a custom git binary or wrapper

--- a/book/src/local.md
+++ b/book/src/local.md
@@ -40,6 +40,11 @@ For a detailed guide on using these commands for multi-package development, see 
 # Change the directory where dependencies are stored (default is .bender)
 database: my_deps_cache
 
+# Share only the bare git repos and lock files across projects, while
+# keeping per-project checkouts under each project's own .bender/.
+# Older Bender versions silently ignore this field.
+db_dir: /var/cache/bender_shared
+
 # Use a custom git binary or wrapper
 git: /usr/local/bin/git-wrapper.sh
 ```

--- a/book/src/workflow/ci.md
+++ b/book/src/workflow/ci.md
@@ -87,16 +87,24 @@ cache:
 
 ## Sharing the Database Across Runs and Projects
 
-When jobs run on a persistent runner, the `database` directory (where Bender stores cloned repositories) can be shared across CI runs and even across projects to drastically reduce fetch times and disk usage.
+When jobs run on a persistent runner, the bare git repositories Bender clones can be shared across CI runs and even across projects to drastically reduce fetch times and disk usage. The recommended way is the [`db_dir`](../configuration.md#db_dir) setting, which relocates *only* the bare repos and lock files; per-project working-tree checkouts stay under each project's own `.bender/` directory and cannot collide.
 
-To enable this, point Bender at a shared location via a [`Bender.local`](../local.md) file (for example placed in a parent directory of the project so it is picked up automatically):
+Place a [`Bender.local`](../local.md) in a parent directory of your projects so it is picked up automatically:
+
+```yaml
+db_dir: /var/cache/bender_shared
+```
+
+Every job on the runner now reuses the already-fetched Git data and serializes safely against concurrent jobs via per-dependency filesystem locks living next to the bare repos (`<db_dir>/git/locks/`).
+
+> **Older Bender versions** silently ignore `db_dir` and fall back to their normal per-project `.bender/` cache, so the shared config above is safe to deploy on a runner that still hosts pinned-to-old-bender projects — those projects simply won't benefit from the shared cache, but they won't misbehave either.
+
+### Legacy `database:` recipe
+
+Earlier docs recommended sharing via [`database`](../configuration.md#database), which relocates both the bare repos *and* the checkouts:
 
 ```yaml
 database: /var/cache/bender_shared
 ```
 
-This way, every job that runs in the runner reuses the already-fetched Git data instead of re-cloning from scratch. See [Configuration](../configuration.md) for more on the `database` setting.
-
-> **Caveats:**
-> - **Checkout collisions:** When sharing the database, checkouts from different projects can collide if the top-level [`Bender.yml`](../manifest.md) does not specify a project-specific `workspace.checkout_dir`. Make sure each top-level project sets its own `checkout_dir` so that checkouts remain isolated even when the database is shared.
-> - **Concurrent runs:** Bender does not currently take a lock before performing Git operations on the shared database. Concurrent jobs that touch the same database may occasionally fail with Git errors. This is unlikely, but worth keeping in mind when sizing parallelism.
+This still works, but it has a known footgun: two top-level projects that share the same name will collide on the same `<database>/git/checkouts/<name>-<hash>/` directory. If you keep this recipe, give each top-level project its own `workspace.checkout_dir` in [`Bender.yml`](../manifest.md) so the checkouts remain isolated. Prefer `db_dir` for new setups.

--- a/book/src/workflow/ci.md
+++ b/book/src/workflow/ci.md
@@ -99,14 +99,14 @@ Every job on the runner now reuses the already-fetched Git data and serializes s
 
 If you'd rather not place a `Bender.local` on the runner at all, exporting `BENDER_DB_DIR=/var/cache/bender_shared` in the job environment has the same effect — any project that explicitly sets `db_dir` in its own configuration overrides the env var.
 
-> **Older Bender versions** silently ignore both `db_dir` and `BENDER_DB_DIR` and fall back to their normal per-project `.bender/` cache, so the shared config above is safe to deploy on a runner that still hosts pinned-to-old-bender projects — those projects simply won't benefit from the shared cache, but they won't misbehave either.
+> **Bender versions before 0.32** silently ignore both `db_dir` and `BENDER_DB_DIR` and fall back to their normal per-project `.bender/` cache, so the shared config above is safe to deploy on a runner that still hosts pinned-to-old-bender projects — those projects simply won't benefit from the shared cache, but they won't misbehave either.
 
-### Legacy `database:` recipe
+### Sharing working-tree checkouts too
 
-Earlier docs recommended sharing via [`database`](../configuration.md#database), which relocates both the bare repos *and* the checkouts:
+If you want to share the bare repos *and* the per-dependency working-tree checkouts (uncommon), use [`database`](../configuration.md#database) instead of `db_dir`:
 
 ```yaml
 database: /var/cache/bender_shared
 ```
 
-This still works, but it has a known footgun: two top-level projects that share the same name will collide on the same `<database>/git/checkouts/<name>-<hash>/` directory. If you keep this recipe, give each top-level project its own `workspace.checkout_dir` in [`Bender.yml`](../manifest.md) so the checkouts remain isolated. Prefer `db_dir` for new setups.
+Caveat: two top-level projects with the same name will collide on the same `<database>/git/checkouts/<name>-<hash>/` directory. Give each top-level project its own `workspace.checkout_dir` in [`Bender.yml`](../manifest.md) so the checkouts remain isolated.

--- a/book/src/workflow/ci.md
+++ b/book/src/workflow/ci.md
@@ -97,7 +97,9 @@ db_dir: /var/cache/bender_shared
 
 Every job on the runner now reuses the already-fetched Git data and serializes safely against concurrent jobs via per-dependency filesystem locks living next to the bare repos (`<db_dir>/git/locks/`).
 
-> **Older Bender versions** silently ignore `db_dir` and fall back to their normal per-project `.bender/` cache, so the shared config above is safe to deploy on a runner that still hosts pinned-to-old-bender projects — those projects simply won't benefit from the shared cache, but they won't misbehave either.
+If you'd rather not place a `Bender.local` on the runner at all, exporting `BENDER_DB_DIR=/var/cache/bender_shared` in the job environment has the same effect — any project that explicitly sets `db_dir` in its own configuration overrides the env var.
+
+> **Older Bender versions** silently ignore both `db_dir` and `BENDER_DB_DIR` and fall back to their normal per-project `.bender/` cache, so the shared config above is safe to deploy on a runner that still hosts pinned-to-old-bender projects — those projects simply won't benefit from the shared cache, but they won't misbehave either.
 
 ### Legacy `database:` recipe
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -508,6 +508,7 @@ fn load_config(from: &Path, warn_config_loaded: bool) -> Result<Config> {
     // Assemble and merge the default configuration.
     let default_cfg = PartialConfig {
         database: Some(from.join(".bender").to_str().unwrap().to_string()),
+        db_dir: None,
         git: Some("git".into()),
         overrides: None,
         plugins: None,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -505,10 +505,14 @@ fn load_config(from: &Path, warn_config_loaded: bool) -> Result<Config> {
         out = out.merge(cfg);
     }
 
-    // Assemble and merge the default configuration.
+    // Assemble and merge the default configuration. Env-var-supplied `db_dir`
+    // lives here so that any configuration file value still wins via
+    // `PartialConfig::merge` (which uses `self.or(other)`).
     let default_cfg = PartialConfig {
         database: Some(from.join(".bender").to_str().unwrap().to_string()),
-        db_dir: None,
+        db_dir: std::env::var("BENDER_DB_DIR")
+            .ok()
+            .filter(|s| !s.is_empty()),
         git: Some("git".into()),
         overrides: None,
         plugins: None,

--- a/src/cmd/audit.rs
+++ b/src/cmd/audit.rs
@@ -150,47 +150,41 @@ pub fn run(sess: &Session, args: &AuditArgs) -> Result<()> {
         }
 
         // if up-to-date:
-        if let Some(ref current_version) = current_version {
-            if version_req_exists {
-                if let Some(highest_version) = highest_version {
-                    if *highest_version == *current_version && !args.only_update {
-                        audit_str.push_str(&format!(
-                            "  is \x1B[32;1mUp-to-date\x1B[m:\t@ {}\n",
-                            current_version_unwrapped
-                        ));
-                    }
-                }
-            }
+        if let Some(ref current_version) = current_version
+            && version_req_exists
+            && let Some(highest_version) = highest_version
+            && *highest_version == *current_version
+            && !args.only_update
+        {
+            audit_str.push_str(&format!(
+                "  is \x1B[32;1mUp-to-date\x1B[m:\t@ {}\n",
+                current_version_unwrapped
+            ));
         }
 
         // if not up-to-date but newest compatible:
-        if let Some(ref current_version) = current_version {
-            if version_req_exists {
-                if let Some(max_compatible) = max_compatible {
-                    if *max_compatible > *current_version {
-                        audit_str.push_str(&format!(
-                            "can \x1B[32;1mAuto-update\x1B[m:\t{} -> {}\n",
-                            current_version_unwrapped, max_compatible
-                        ));
-                    }
-                }
-            }
+        if let Some(ref current_version) = current_version
+            && version_req_exists
+            && let Some(max_compatible) = max_compatible
+            && *max_compatible > *current_version
+        {
+            audit_str.push_str(&format!(
+                "can \x1B[32;1mAuto-update\x1B[m:\t{} -> {}\n",
+                current_version_unwrapped, max_compatible
+            ));
         }
 
         // if not up-to-date and newest incompatible:
-        if let Some(current_version) = current_version {
-            if version_req_exists {
-                if let Some(highest_version) = highest_version {
-                    if *highest_version > current_version
-                        && (max_compatible.is_none() || *max_compatible.unwrap() < *highest_version)
-                    {
-                        audit_str.push_str(&format!(
-                            "     can \x1B[33;1mUpdate\x1B[m:\t{} -> {}\n",
-                            current_version_unwrapped, highest_version
-                        ));
-                    }
-                }
-            }
+        if let Some(current_version) = current_version
+            && version_req_exists
+            && let Some(highest_version) = highest_version
+            && *highest_version > current_version
+            && (max_compatible.is_none() || *max_compatible.unwrap() < *highest_version)
+        {
+            audit_str.push_str(&format!(
+                "     can \x1B[33;1mUpdate\x1B[m:\t{} -> {}\n",
+                current_version_unwrapped, highest_version
+            ));
         }
     }
 

--- a/src/cmd/snapshot.rs
+++ b/src/cmd/snapshot.rs
@@ -51,60 +51,56 @@ pub fn run(sess: &Session, args: &SnapshotArgs) -> Result<()> {
             path: override_path,
             ..
         } = dep
+            && override_path.starts_with(sess.root.join(&args.working_dir))
+            && let DependencySource::Path(dep_path) =
+                sess.dependency_source(sess.dependency_with_name(name)?)
+            && dep_path == *override_path
         {
-            if override_path.starts_with(sess.root.join(&args.working_dir)) {
-                if let DependencySource::Path(dep_path) =
-                    sess.dependency_source(sess.dependency_with_name(name)?)
-                {
-                    if dep_path == *override_path {
-                        // check state, skip & warn if dirty
-                        if !SysCommand::new(&sess.config.git)
-                            .arg("status")
-                            .arg("--porcelain")
-                            .current_dir(&dep_path)
-                            .output()
-                            .into_diagnostic()?
-                            .stdout
-                            .is_empty()
-                            && !args.no_skip
-                        {
-                            Warnings::SkippingDirtyDep { pkg: name.clone() }.emit();
-                            continue;
-                        }
-
-                        // Get the git url and hash of the dependency
-                        let url = match String::from_utf8(
-                            SysCommand::new(&sess.config.git)
-                                .arg("remote")
-                                .arg("get-url")
-                                .arg("origin")
-                                .current_dir(&dep_path)
-                                .output()
-                                .into_diagnostic()?
-                                .stdout,
-                        ) {
-                            Ok(url) => url.trim_end_matches(&['\r', '\n'][..]).to_string(),
-                            Err(_) => bail!("Failed to get git url."),
-                        };
-                        let hash = match String::from_utf8(
-                            SysCommand::new(&sess.config.git)
-                                .arg("rev-parse")
-                                .arg("HEAD")
-                                .current_dir(&dep_path)
-                                .output()
-                                .into_diagnostic()?
-                                .stdout,
-                        ) {
-                            Ok(hash) => hash.trim_end_matches(&['\r', '\n'][..]).to_string(),
-                            Err(_) => bail!("Failed to get git hash."),
-                        };
-
-                        eprintln!("Snapshotting {} at {} from {}", name, hash, url);
-
-                        snapshot_list.push((name.clone(), url, hash));
-                    }
-                }
+            // check state, skip & warn if dirty
+            if !SysCommand::new(&sess.config.git)
+                .arg("status")
+                .arg("--porcelain")
+                .current_dir(&dep_path)
+                .output()
+                .into_diagnostic()?
+                .stdout
+                .is_empty()
+                && !args.no_skip
+            {
+                Warnings::SkippingDirtyDep { pkg: name.clone() }.emit();
+                continue;
             }
+
+            // Get the git url and hash of the dependency
+            let url = match String::from_utf8(
+                SysCommand::new(&sess.config.git)
+                    .arg("remote")
+                    .arg("get-url")
+                    .arg("origin")
+                    .current_dir(&dep_path)
+                    .output()
+                    .into_diagnostic()?
+                    .stdout,
+            ) {
+                Ok(url) => url.trim_end_matches(&['\r', '\n'][..]).to_string(),
+                Err(_) => bail!("Failed to get git url."),
+            };
+            let hash = match String::from_utf8(
+                SysCommand::new(&sess.config.git)
+                    .arg("rev-parse")
+                    .arg("HEAD")
+                    .current_dir(&dep_path)
+                    .output()
+                    .into_diagnostic()?
+                    .stdout,
+            ) {
+                Ok(hash) => hash.trim_end_matches(&['\r', '\n'][..]).to_string(),
+                Err(_) => bail!("Failed to get git hash."),
+            };
+
+            eprintln!("Snapshotting {} at {} from {}", name, hash, url);
+
+            snapshot_list.push((name.clone(), url, hash));
         }
     }
 

--- a/src/cmd/update.rs
+++ b/src/cmd/update.rs
@@ -88,15 +88,15 @@ pub fn run<'ctx>(
     }
 
     // Unlock dependencies recursively
-    if args.recursive {
-        if let Some(existing_locked) = existing {
-            let mut nochange = true;
-            while nochange {
-                nochange = false;
-                for dep in requested.clone().iter() {
-                    for needed_dep in existing_locked.packages[dep].dependencies.iter() {
-                        nochange |= requested.insert(needed_dep.clone());
-                    }
+    if args.recursive
+        && let Some(existing_locked) = existing
+    {
+        let mut nochange = true;
+        while nochange {
+            nochange = false;
+            for dep in requested.clone().iter() {
+                for needed_dep in existing_locked.packages[dep].dependencies.iter() {
+                    nochange |= requested.insert(needed_dep.clone());
                 }
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1177,7 +1177,7 @@ impl Validate for PartialSources {
 
                 let post_env_files: Vec<PartialSourceFile> = if let Some(fls) = files {
                     fls.into_iter()
-                        .chain(external_flist_groups?.into_iter())
+                        .chain(external_flist_groups?)
                         .filter_map(|file| match file {
                             PartialSourceFile::File(ref filename)
                             | PartialSourceFile::SvFile(ref filename)
@@ -1447,46 +1447,38 @@ impl GlobFile for PartialSourceFile {
             PartialSourceFile::File(ref path)
             | PartialSourceFile::SvFile(ref path)
             | PartialSourceFile::VerilogFile(ref path)
-            | PartialSourceFile::VhdlFile(ref path) => {
-                // Check if glob patterns used
-                if path.contains("*") || path.contains("?") {
-                    let glob_matches = glob(path)
-                        .into_diagnostic()
-                        .wrap_err_with(|| format!("Invalid glob pattern for {:?}", path))?;
-                    let out = glob_matches
-                        .map(|glob_match| {
-                            let file_str = glob_match
-                                .into_diagnostic()
-                                .wrap_err_with(|| format!("Glob match failed for {:?}", path))?
-                                .to_str()
-                                .unwrap()
-                                .to_string();
-                            Ok(match self {
-                                PartialSourceFile::File(_) => PartialSourceFile::File(file_str),
-                                PartialSourceFile::SvFile(_) => PartialSourceFile::SvFile(file_str),
-                                PartialSourceFile::VerilogFile(_) => {
-                                    PartialSourceFile::VerilogFile(file_str)
-                                }
-                                PartialSourceFile::VhdlFile(_) => {
-                                    PartialSourceFile::VhdlFile(file_str)
-                                }
-                                _ => unreachable!(),
-                            })
+            | PartialSourceFile::VhdlFile(ref path)
+                if path.contains("*") || path.contains("?") =>
+            {
+                let glob_matches = glob(path)
+                    .into_diagnostic()
+                    .wrap_err_with(|| format!("Invalid glob pattern for {:?}", path))?;
+                let out = glob_matches
+                    .map(|glob_match| {
+                        let file_str = glob_match
+                            .into_diagnostic()
+                            .wrap_err_with(|| format!("Glob match failed for {:?}", path))?
+                            .to_str()
+                            .unwrap()
+                            .to_string();
+                        Ok(match self {
+                            PartialSourceFile::File(_) => PartialSourceFile::File(file_str),
+                            PartialSourceFile::SvFile(_) => PartialSourceFile::SvFile(file_str),
+                            PartialSourceFile::VerilogFile(_) => {
+                                PartialSourceFile::VerilogFile(file_str)
+                            }
+                            PartialSourceFile::VhdlFile(_) => PartialSourceFile::VhdlFile(file_str),
+                            _ => unreachable!(),
                         })
-                        .collect::<Result<Vec<PartialSourceFile>>>()?;
-                    if out.is_empty() {
-                        Warnings::NoFilesForGlobPattern { path: path.clone() }.emit();
-                    }
-                    Ok(out)
-                } else {
-                    // Return self if not a glob pattern
-                    Ok(vec![self])
+                    })
+                    .collect::<Result<Vec<PartialSourceFile>>>()?;
+                if out.is_empty() {
+                    Warnings::NoFilesForGlobPattern { path: path.clone() }.emit();
                 }
+                Ok(out)
             }
-            _ => {
-                // Return self if not a glob pattern
-                Ok(vec![self])
-            }
+            // Return self if not a glob pattern (also matches non-file variants).
+            _ => Ok(vec![self]),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1623,6 +1623,11 @@ where
 pub struct Config {
     /// The path to the database directory.
     pub database: PathBuf,
+    /// Optional override for the directory containing bare git repositories
+    /// and their lock files. When set, takes precedence over `database` for
+    /// these two specific paths; checkouts and everything else still derive
+    /// from `database`.
+    pub db_dir: Option<PathBuf>,
     /// The git command or path to the binary.
     pub git: String,
     /// The dependency overrides.
@@ -1640,6 +1645,8 @@ pub struct Config {
 pub struct PartialConfig {
     /// The path to the database directory.
     pub database: Option<String>,
+    /// Optional override for the bare-repo and lock directory.
+    pub db_dir: Option<String>,
     /// The git command or path to the binary.
     pub git: Option<String>,
     /// The dependency overrides.
@@ -1663,6 +1670,7 @@ impl PrefixPaths for PartialConfig {
     fn prefix_paths(self, prefix: &Path) -> Result<Self> {
         Ok(PartialConfig {
             database: self.database.prefix_paths(prefix)?,
+            db_dir: self.db_dir.prefix_paths(prefix)?,
             overrides: self.overrides.prefix_paths(prefix)?,
             plugins: self.plugins.prefix_paths(prefix)?,
             ..self
@@ -1674,6 +1682,7 @@ impl Merge for PartialConfig {
     fn merge(self, other: PartialConfig) -> PartialConfig {
         PartialConfig {
             database: self.database.or(other.database),
+            db_dir: self.db_dir.or(other.db_dir),
             git: self.git.or(other.git),
             overrides: match (self.overrides, other.overrides) {
                 (Some(o), None) | (None, Some(o)) => Some(o),
@@ -1709,6 +1718,10 @@ impl Validate for PartialConfig {
             database: match self.database {
                 Some(db) => env_path_from_string(&db)?,
                 None => bail!("Database directory not configured"),
+            },
+            db_dir: match self.db_dir {
+                Some(d) => Some(env_path_from_string(&d)?),
+                None => None,
             },
             git: match self.git {
                 Some(git) => git,

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -116,10 +116,10 @@ impl Warnings {
         let diag = Diagnostics::get();
 
         // Check whether the command is suppressed
-        if let Some(code) = self.code() {
-            if diag.all_suppressed || diag.suppressed.contains(&code.to_string()) {
-                return;
-            }
+        if let Some(code) = self.code()
+            && (diag.all_suppressed || diag.suppressed.contains(&code.to_string()))
+        {
+            return;
         }
 
         // Check whether the warning was already emitted

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod cmd;
 pub mod config;
 pub mod diagnostic;
 pub mod git;
+pub mod lock;
 pub mod lockfile;
 pub mod progress;
 pub mod resolver;

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -9,10 +9,9 @@
 
 #![deny(missing_docs)]
 
-use std::fs::{File, OpenOptions};
+use std::fs::{File, OpenOptions, TryLockError};
 use std::path::{Path, PathBuf};
 
-use fs4::{FileExt, TryLockError};
 use miette::{Context as _, IntoDiagnostic as _};
 
 use crate::Result;
@@ -49,11 +48,11 @@ impl FsLock {
 
         let path_for_blocking = path.clone();
         let file = tokio::task::spawn_blocking(move || -> Result<File> {
-            match FileExt::try_lock(&file) {
+            match file.try_lock() {
                 Ok(()) => Ok(file),
                 Err(TryLockError::WouldBlock) => {
                     log::info!("waiting for lock on {:?}", path_for_blocking);
-                    FileExt::lock(&file).into_diagnostic().wrap_err_with(|| {
+                    file.lock().into_diagnostic().wrap_err_with(|| {
                         format!("Failed to acquire lock on {:?}.", path_for_blocking)
                     })?;
                     Ok(file)
@@ -84,7 +83,7 @@ impl Drop for FsLock {
         if let Some(file) = self.file.take() {
             // Best-effort: errors here are not actionable, and the OS releases
             // the lock automatically when the file handle closes.
-            let _ = FileExt::unlock(&file);
+            let _ = file.unlock();
         }
     }
 }

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -53,16 +53,14 @@ impl FsLock {
                 Ok(()) => Ok(file),
                 Err(TryLockError::WouldBlock) => {
                     log::info!("waiting for lock on {:?}", path_for_blocking);
-                    FileExt::lock(&file)
-                        .into_diagnostic()
-                        .wrap_err_with(|| {
-                            format!("Failed to acquire lock on {:?}.", path_for_blocking)
-                        })?;
+                    FileExt::lock(&file).into_diagnostic().wrap_err_with(|| {
+                        format!("Failed to acquire lock on {:?}.", path_for_blocking)
+                    })?;
                     Ok(file)
                 }
-                Err(TryLockError::Error(e)) => Err(e).into_diagnostic().wrap_err_with(|| {
-                    format!("Failed to try-lock {:?}.", path_for_blocking)
-                }),
+                Err(TryLockError::Error(e)) => Err(e)
+                    .into_diagnostic()
+                    .wrap_err_with(|| format!("Failed to try-lock {:?}.", path_for_blocking)),
             }
         })
         .await

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,0 +1,92 @@
+// Copyright (c) 2025 ETH Zurich
+
+//! Cross-process filesystem advisory locks.
+//!
+//! Bender uses these to serialize concurrent invocations against the same git
+//! database and checkout. The lock is taken on a sentinel file in
+//! `<database>/git/locks/<name>-<hash>.lock` and released automatically when
+//! the [`FsLock`] guard is dropped.
+
+#![deny(missing_docs)]
+
+use std::fs::{File, OpenOptions};
+use std::path::{Path, PathBuf};
+
+use fs4::{FileExt, TryLockError};
+use miette::{Context as _, IntoDiagnostic as _};
+
+use crate::Result;
+
+/// An exclusive, cross-process advisory lock held on a sentinel file.
+///
+/// The lock is released when this guard is dropped (or when the process exits).
+pub struct FsLock {
+    file: Option<File>,
+    path: PathBuf,
+}
+
+impl FsLock {
+    /// Acquire an exclusive lock on `path`, creating the file if missing.
+    ///
+    /// If the lock is contended, an info message is logged so the user can see
+    /// why bender is waiting, and the call then blocks until the lock is
+    /// available. The actual lock acquisition runs on a blocking worker so it
+    /// does not stall the tokio runtime.
+    pub async fn acquire_exclusive(path: PathBuf) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .into_diagnostic()
+                .wrap_err_with(|| format!("Failed to create lock directory {:?}.", parent))?;
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&path)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("Failed to open lock file {:?}.", path))?;
+
+        let path_for_blocking = path.clone();
+        let file = tokio::task::spawn_blocking(move || -> Result<File> {
+            match FileExt::try_lock(&file) {
+                Ok(()) => Ok(file),
+                Err(TryLockError::WouldBlock) => {
+                    log::info!("waiting for lock on {:?}", path_for_blocking);
+                    FileExt::lock(&file)
+                        .into_diagnostic()
+                        .wrap_err_with(|| {
+                            format!("Failed to acquire lock on {:?}.", path_for_blocking)
+                        })?;
+                    Ok(file)
+                }
+                Err(TryLockError::Error(e)) => Err(e).into_diagnostic().wrap_err_with(|| {
+                    format!("Failed to try-lock {:?}.", path_for_blocking)
+                }),
+            }
+        })
+        .await
+        .into_diagnostic()
+        .wrap_err("Lock acquisition task panicked.")??;
+
+        Ok(FsLock {
+            file: Some(file),
+            path,
+        })
+    }
+
+    /// The path of the lock file.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for FsLock {
+    fn drop(&mut self) {
+        if let Some(file) = self.file.take() {
+            // Best-effort: errors here are not actionable, and the OS releases
+            // the lock automatically when the file handle closes.
+            let _ = FileExt::unlock(&file);
+        }
+    }
+}

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -209,69 +209,67 @@ impl ProgressHandler {
         match progress {
             // This case is only relevant for submodule operations i.e. `git submodule update`
             // It indicates that a new submodule has been registered, and we create a new progress bar for it.
-            GitProgress::SubmoduleRegistered { name } => {
-                if self.git_op == GitProgressOps::Submodule {
-                    // The main bar simply becomes a spinner since the sub-bar will show progress
-                    // on the subsequent line.
-                    state.pb.set_style(
-                        ProgressStyle::with_template("{spinner:>3.cyan} {prefix:<40!}").unwrap(),
-                    );
+            GitProgress::SubmoduleRegistered { name }
+                if self.git_op == GitProgressOps::Submodule =>
+            {
+                // The main bar simply becomes a spinner since the sub-bar will show progress
+                // on the subsequent line.
+                state.pb.set_style(
+                    ProgressStyle::with_template("{spinner:>3.cyan} {prefix:<40!}").unwrap(),
+                );
 
-                    // The submodule style is similar to the main bar, but indented and without spinner
-                    let style = ProgressStyle::with_template(
-                        "     {prefix:<24!} {bar:40.cyan/blue} {percent:>3}% {msg}",
-                    )
+                // The submodule style is similar to the main bar, but indented and without spinner
+                let style = ProgressStyle::with_template(
+                    "     {prefix:<24!} {bar:40.cyan/blue} {percent:>3}% {msg}",
+                )
+                .unwrap()
+                .progress_chars("-- ");
+
+                // We can have multiple sub-bars, and we insert them after the last one.
+                // In order to maintain proper tree-like structure, we need to update the previous last bar
+                // to have a "T" connector (├─) instead of an "L"
+                let prev_bar = match state.sub_bars.last() {
+                    Some((last_name, last_pb)) => {
+                        let prev_prefix = format!("{} {}", fmt_dim!("├─"), last_name);
+                        last_pb.set_prefix(prev_prefix);
+                        last_pb // Insert the new one after this one
+                    }
+                    None => &state.pb, // Insert the first one after the main bar
+                };
+
+                // Create the new sub-bar and insert it in the multi-progress *after* the previous sub-bar
+                let sub_pb = self
+                    .multiprogress
+                    .as_ref()
                     .unwrap()
-                    .progress_chars("-- ");
+                    .insert_after(prev_bar, ProgressBar::new(100).with_style(style));
+                // Set the prefix and initial message
+                let sub_prefix = format!("{} {}", fmt_dim!("╰─"), &name);
+                sub_pb.set_prefix(sub_prefix);
+                sub_pb.set_message(format!("{}", fmt_dim!("Waiting...")));
 
-                    // We can have multiple sub-bars, and we insert them after the last one.
-                    // In order to maintain proper tree-like structure, we need to update the previous last bar
-                    // to have a "T" connector (├─) instead of an "L"
-                    let prev_bar = match state.sub_bars.last() {
-                        Some((last_name, last_pb)) => {
-                            let prev_prefix = format!("{} {}", fmt_dim!("├─"), last_name);
-                            last_pb.set_prefix(prev_prefix);
-                            last_pb // Insert the new one after this one
-                        }
-                        None => &state.pb, // Insert the first one after the main bar
-                    };
-
-                    // Create the new sub-bar and insert it in the multi-progress *after* the previous sub-bar
-                    let sub_pb = self
-                        .multiprogress
-                        .as_ref()
-                        .unwrap()
-                        .insert_after(prev_bar, ProgressBar::new(100).with_style(style));
-                    // Set the prefix and initial message
-                    let sub_prefix = format!("{} {}", fmt_dim!("╰─"), &name);
-                    sub_pb.set_prefix(sub_prefix);
-                    sub_pb.set_message(format!("{}", fmt_dim!("Waiting...")));
-
-                    // Store the sub-bar in the state for later updates
-                    state.sub_bars.insert(name, sub_pb);
-                }
+                // Store the sub-bar in the state for later updates
+                state.sub_bars.insert(name, sub_pb);
             }
             // This indicates that we are starting to clone a submodule.
             // Again, it is only relevant for submodule operations. For normal
             // clones, we just update the main bar.
-            GitProgress::CloningInto { name } => {
-                if self.git_op == GitProgressOps::Submodule {
-                    // Logic to handle missing 'checked out' lines:
-                    // If we are activating 'bar', but 'foo' was active, assume 'foo' is done.
-                    if let Some(prev) = &state.active_sub {
-                        if prev != &name {
-                            if let Some(b) = state.sub_bars.get(prev) {
-                                b.finish_and_clear();
-                            }
+            GitProgress::CloningInto { name } if self.git_op == GitProgressOps::Submodule => {
+                // Logic to handle missing 'checked out' lines:
+                // If we are activating 'bar', but 'foo' was active, assume 'foo' is done.
+                if let Some(prev) = &state.active_sub {
+                    if prev != &name {
+                        if let Some(b) = state.sub_bars.get(prev) {
+                            b.finish_and_clear();
                         }
                     }
-                    // Set the new bar to active
-                    if let Some(bar) = state.sub_bars.get(&name) {
-                        // Switch style to the active progress bar style
-                        bar.set_message(format!("{}", fmt_dim!("Cloning...")));
-                    }
-                    state.active_sub = Some(name);
                 }
+                // Set the new bar to active
+                if let Some(bar) = state.sub_bars.get(&name) {
+                    // Switch style to the active progress bar style
+                    bar.set_message(format!("{}", fmt_dim!("Cloning...")));
+                }
+                state.active_sub = Some(name);
             }
             // Indicates that we have finished processing a submodule.
             GitProgress::SubmoduleEnd { name } => {

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -257,12 +257,11 @@ impl ProgressHandler {
             GitProgress::CloningInto { name } if self.git_op == GitProgressOps::Submodule => {
                 // Logic to handle missing 'checked out' lines:
                 // If we are activating 'bar', but 'foo' was active, assume 'foo' is done.
-                if let Some(prev) = &state.active_sub {
-                    if prev != &name {
-                        if let Some(b) = state.sub_bars.get(prev) {
-                            b.finish_and_clear();
-                        }
-                    }
+                if let Some(prev) = &state.active_sub
+                    && prev != &name
+                    && let Some(b) = state.sub_bars.get(prev)
+                {
+                    b.finish_and_clear();
                 }
                 // Set the new bar to active
                 if let Some(bar) = state.sub_bars.get(&name) {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -84,59 +84,58 @@ impl<'ctx> DependencyResolver<'ctx> {
         }
 
         // Store path dependencies already in checkout_dir
-        if let Some(ref checkout) = self.sess.manifest.workspace.checkout_dir {
-            if checkout.exists() {
-                for dir in fs::read_dir(checkout).into_diagnostic()? {
-                    let depname = dir
-                        .as_ref()
-                        .unwrap()
-                        .path()
-                        .file_name()
-                        .unwrap()
-                        .to_str()
-                        .unwrap()
-                        .to_string();
+        if let Some(ref checkout) = self.sess.manifest.workspace.checkout_dir
+            && checkout.exists()
+        {
+            for dir in fs::read_dir(checkout).into_diagnostic()? {
+                let depname = dir
+                    .as_ref()
+                    .unwrap()
+                    .path()
+                    .file_name()
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+                    .to_string();
 
-                    let is_git_repo = dir.as_ref().unwrap().path().join(".git").exists();
+                let is_git_repo = dir.as_ref().unwrap().path().join(".git").exists();
 
-                    // Only act if the avoiding flag is not set and any of the following match
-                    //  - the dependency is not a git repo
-                    //  - the dependency is not in a clean state (i.e., was modified)
-                    if !ignore_checkout {
-                        if !is_git_repo {
-                            Warnings::NotAGitDependency(depname.clone(), checkout.clone()).emit();
-                            self.checked_out.insert(
-                                depname,
-                                config::Dependency::Path {
-                                    target: TargetSpec::Wildcard,
-                                    path: dir.unwrap().path(),
-                                    pass_targets: vec![],
-                                },
-                            );
-                        } else if !(SysCommand::new(&self.sess.config.git) // If not in a clean state
-                            .arg("status")
-                            .arg("--porcelain")
-                            .current_dir(dir.as_ref().unwrap().path())
-                            .output()
-                            .into_diagnostic()?
-                            .stdout
-                            .is_empty())
-                        {
-                            Warnings::DirtyGitDependency(depname.clone(), checkout.clone()).emit();
-                            self.checked_out.insert(
-                                depname,
-                                config::Dependency::Path {
-                                    target: TargetSpec::Wildcard,
-                                    path: dir.unwrap().path(),
-                                    pass_targets: vec![],
-                                },
-                            );
-                        }
+                // Only act if the avoiding flag is not set and any of the following match
+                //  - the dependency is not a git repo
+                //  - the dependency is not in a clean state (i.e., was modified)
+                if !ignore_checkout {
+                    if !is_git_repo {
+                        Warnings::NotAGitDependency(depname.clone(), checkout.clone()).emit();
+                        self.checked_out.insert(
+                            depname,
+                            config::Dependency::Path {
+                                target: TargetSpec::Wildcard,
+                                path: dir.unwrap().path(),
+                                pass_targets: vec![],
+                            },
+                        );
+                    } else if !(SysCommand::new(&self.sess.config.git) // If not in a clean state
+                        .arg("status")
+                        .arg("--porcelain")
+                        .current_dir(dir.as_ref().unwrap().path())
+                        .output()
+                        .into_diagnostic()?
+                        .stdout
+                        .is_empty())
+                    {
+                        Warnings::DirtyGitDependency(depname.clone(), checkout.clone()).emit();
+                        self.checked_out.insert(
+                            depname,
+                            config::Dependency::Path {
+                                target: TargetSpec::Wildcard,
+                                path: dir.unwrap().path(),
+                                pass_targets: vec![],
+                            },
+                        );
                     }
                 }
             }
         }
-
         // Load the plugin dependencies.
         self.register_dependencies_in_manifest(
             &self.sess.config.plugins,
@@ -708,17 +707,15 @@ impl<'ctx> DependencyResolver<'ctx> {
                     indices_list?
                 };
                 if indices_list.is_empty() {
-                    if let DependencyConstraint::Revision(rev) = con {
-                        if !self.refetched.contains(&(*id, Some(rev.clone()))) {
-                            // attempt refetch with rev
-                            self.refetched.insert((*id, Some(rev.clone())));
-                            if let Ok(new_versions) = rt.block_on(io.dependency_versions(
-                                *id,
-                                Some(true),
-                                Some(rev.as_str()),
-                            )) {
-                                src.versions = new_versions;
-                            }
+                    if let DependencyConstraint::Revision(rev) = con
+                        && !self.refetched.contains(&(*id, Some(rev.clone())))
+                    {
+                        // attempt refetch with rev
+                        self.refetched.insert((*id, Some(rev.clone())));
+                        if let Ok(new_versions) =
+                            rt.block_on(io.dependency_versions(*id, Some(true), Some(rev.as_str())))
+                        {
+                            src.versions = new_versions;
                         }
                     }
                 } else {

--- a/src/sess.rs
+++ b/src/sess.rs
@@ -568,11 +568,22 @@ impl<'ctx> Session<'ctx> {
     /// working checkout under `git/checkouts/` for this dependency.
     pub fn dep_lock_path(&self, name: &str, url: &str) -> PathBuf {
         let key = self.git_db_name(name, url);
-        self.config
-            .database
+        self.db_parent()
             .join("git")
             .join("locks")
             .join(format!("{}.lock", key))
+    }
+
+    /// The directory under which bare git databases and lock files live.
+    ///
+    /// Uses `db_dir` if configured (the recommended way to share bare repos
+    /// across projects without relocating checkouts), otherwise falls back to
+    /// `database`.
+    pub fn db_parent(&self) -> &Path {
+        self.config
+            .db_dir
+            .as_deref()
+            .unwrap_or(&self.config.database)
     }
 }
 
@@ -694,13 +705,7 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
 
         // Determine the location of the git database and create it if its does
         // not yet exist.
-        let db_dir = self
-            .sess
-            .config
-            .database
-            .join("git")
-            .join("db")
-            .join(db_name);
+        let db_dir = self.sess.db_parent().join("git").join("db").join(db_name);
         let db_dir = self.sess.intern_path(db_dir);
         std::fs::create_dir_all(db_dir)
             .into_diagnostic()

--- a/src/sess.rs
+++ b/src/sess.rs
@@ -873,8 +873,7 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
                 versions.sort_by(|a, b| b.cmp(a));
 
                 // Merge tags and branches.
-                let refs: IndexMap<&str, &str> =
-                    branches.into_iter().chain(tags.into_iter()).collect();
+                let refs: IndexMap<&str, &str> = branches.into_iter().chain(tags).collect();
 
                 let git_path = git.path;
 

--- a/src/sess.rs
+++ b/src/sess.rs
@@ -1257,91 +1257,90 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
         used_git_rev: &str,
     ) -> Result<()> {
         for dep in (dep_iter_mut).iter_mut() {
-            if let (_, config::Dependency::Path { path, .. }) = dep {
-                if !path.starts_with("/") {
-                    Warnings::PathDepInGitDep {
-                        pkg: dep.0.clone(),
-                        top_pkg: top_package_name.clone(),
-                    }
-                    .emit();
+            if let (_, config::Dependency::Path { path, .. }) = dep
+                && !path.starts_with("/")
+            {
+                Warnings::PathDepInGitDep {
+                    pkg: dep.0.clone(),
+                    top_pkg: top_package_name.clone(),
+                }
+                .emit();
 
-                    let sub_entries = db
-                        .clone()
-                        .list_files(
+                let sub_entries = db
+                    .clone()
+                    .list_files(
+                        used_git_rev,
+                        Some(
+                            reference_path
+                                .strip_prefix(dep_base_path)
+                                .unwrap()
+                                .join(&mut *path)
+                                .join("Bender.yml"),
+                        ),
+                    )
+                    .await?;
+                let sub_data = match sub_entries.into_iter().next() {
+                    None => Ok(None),
+                    Some(sub_entry) => db.clone().cat_file(sub_entry.hash).await.map(Some),
+                }?;
+
+                let sub_dep_path = reference_path.join(path);
+
+                let tmp_path = self.sess.root.join(".bender").join("tmp");
+
+                if let Some(ref full_sub_data) = sub_data {
+                    if !tmp_path.exists() {
+                        std::fs::create_dir_all(&tmp_path).into_diagnostic()?;
+                    }
+                    let mut sub_file = std::fs::OpenOptions::new()
+                        .write(true)
+                        .truncate(true)
+                        .create(true)
+                        .open(tmp_path.join(format!("{}_manifest.yml", dep.0)))
+                        .into_diagnostic()?;
+                    writeln!(&mut sub_file, "{}", full_sub_data).into_diagnostic()?;
+                    sub_file.flush().into_diagnostic()?;
+                }
+
+                *dep.1 = config::Dependency::Path {
+                    target: TargetSpec::Wildcard,
+                    path: sub_dep_path.clone(),
+                    pass_targets: Vec::new(),
+                };
+
+                // Further dependencies
+                let _manifest: Result<_> = match sub_data {
+                    Some(data) => {
+                        let partial: config::PartialManifest = serde_yaml_ng::from_str(&data)
+                            .into_diagnostic()
+                            .wrap_err_with(|| {
+                                format!(
+                                    "Syntax error in manifest of dependency `{}` at \
+                                                 revision `{}`.",
+                                    dep.0, used_git_rev
+                                )
+                            })?;
+                        let mut full = partial.validate_ignore_sources().wrap_err_with(|| {
+                            format!(
+                                "Error in manifest of dependency `{}` at revision \
+                                             `{}`.",
+                                dep.0, used_git_rev
+                            )
+                        })?;
+                        self.sub_dependency_fixing(
+                            &mut full.dependencies,
+                            full.package.name.clone(),
+                            &sub_dep_path,
+                            dep_base_path,
+                            db.clone(),
                             used_git_rev,
-                            Some(
-                                reference_path
-                                    .strip_prefix(dep_base_path)
-                                    .unwrap()
-                                    .join(&mut *path)
-                                    .join("Bender.yml"),
-                            ),
                         )
                         .await?;
-                    let sub_data = match sub_entries.into_iter().next() {
-                        None => Ok(None),
-                        Some(sub_entry) => db.clone().cat_file(sub_entry.hash).await.map(Some),
-                    }?;
 
-                    let sub_dep_path = reference_path.join(path);
-
-                    let tmp_path = self.sess.root.join(".bender").join("tmp");
-
-                    if let Some(ref full_sub_data) = sub_data {
-                        if !tmp_path.exists() {
-                            std::fs::create_dir_all(&tmp_path).into_diagnostic()?;
-                        }
-                        let mut sub_file = std::fs::OpenOptions::new()
-                            .write(true)
-                            .truncate(true)
-                            .create(true)
-                            .open(tmp_path.join(format!("{}_manifest.yml", dep.0)))
-                            .into_diagnostic()?;
-                        writeln!(&mut sub_file, "{}", full_sub_data).into_diagnostic()?;
-                        sub_file.flush().into_diagnostic()?;
+                        Ok(())
                     }
-
-                    *dep.1 = config::Dependency::Path {
-                        target: TargetSpec::Wildcard,
-                        path: sub_dep_path.clone(),
-                        pass_targets: Vec::new(),
-                    };
-
-                    // Further dependencies
-                    let _manifest: Result<_> = match sub_data {
-                        Some(data) => {
-                            let partial: config::PartialManifest = serde_yaml_ng::from_str(&data)
-                                .into_diagnostic()
-                                .wrap_err_with(|| {
-                                    format!(
-                                        "Syntax error in manifest of dependency `{}` at \
-                                                 revision `{}`.",
-                                        dep.0, used_git_rev
-                                    )
-                                })?;
-                            let mut full =
-                                partial.validate_ignore_sources().wrap_err_with(|| {
-                                    format!(
-                                        "Error in manifest of dependency `{}` at revision \
-                                             `{}`.",
-                                        dep.0, used_git_rev
-                                    )
-                                })?;
-                            self.sub_dependency_fixing(
-                                &mut full.dependencies,
-                                full.package.name.clone(),
-                                &sub_dep_path,
-                                dep_base_path,
-                                db.clone(),
-                                used_git_rev,
-                            )
-                            .await?;
-
-                            Ok(())
-                        }
-                        None => Ok(()),
-                    };
-                }
+                    None => Ok(()),
+                };
             }
         }
         Ok(())
@@ -1973,10 +1972,10 @@ impl<'ctx> DependencyTable<'ctx> {
             log::debug!("reusing {:?}", id);
             id
         } else {
-            if let DependencySource::Path(path) = &entry.source {
-                if !path.exists() {
-                    Warnings::DepSourcePathMissing(entry.name.clone(), path.clone()).emit();
-                }
+            if let DependencySource::Path(path) = &entry.source
+                && !path.exists()
+            {
+                Warnings::DepSourcePathMissing(entry.name.clone(), path.clone()).emit();
             }
             let id = DependencyRef(self.list.len());
             log::debug!("adding {:?} as {:?}", entry, id);

--- a/src/sess.rs
+++ b/src/sess.rs
@@ -37,6 +37,7 @@ use crate::cli::read_manifest;
 use crate::config::{self, Config, Manifest, PartialManifest};
 use crate::diagnostic::{Diagnostics, Errors, Warnings};
 use crate::git::Git;
+use crate::lock::FsLock;
 use crate::progress::{GitProgressOps, ProgressHandler};
 use crate::src::{SourceFile, SourceGroup, SourceType};
 use crate::target::TargetSpec;
@@ -560,6 +561,19 @@ impl<'ctx> Session<'ctx> {
         let db_name = format!("{}-{}", name, hash);
         db_name
     }
+
+    /// Path of the cross-process advisory lock file for a git dependency.
+    ///
+    /// The same file guards both the bare database under `git/db/` and the
+    /// working checkout under `git/checkouts/` for this dependency.
+    pub fn dep_lock_path(&self, name: &str, url: &str) -> PathBuf {
+        let key = self.git_db_name(name, url);
+        self.config
+            .database
+            .join("git")
+            .join("locks")
+            .join(format!("{}.lock", key))
+    }
 }
 
 /// A wrapper around a `Session` that provides async IO operations.
@@ -642,9 +656,28 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
 
     /// Access the git database for a dependency.
     ///
+    /// Acquires the per-dependency filesystem lock and delegates to
+    /// [`git_database_locked`]. Callers that already hold the lock for this
+    /// dependency should call [`git_database_locked`] directly to avoid
+    /// deadlocking.
+    async fn git_database(
+        &'io self,
+        name: &str,
+        url: &str,
+        force_fetch: Option<bool>,
+        fetch_ref: Option<&str>,
+    ) -> Result<Git<'ctx>> {
+        let _lock = FsLock::acquire_exclusive(self.sess.dep_lock_path(name, url)).await?;
+        self.git_database_locked(name, url, force_fetch, fetch_ref)
+            .await
+    }
+
+    /// Access the git database for a dependency, assuming the per-dependency
+    /// filesystem lock is already held by the caller.
+    ///
     /// If the database does not exist, it is created. If the database has not
     /// been updated recently, the remote is fetched.
-    async fn git_database(
+    async fn git_database_locked(
         &'io self,
         name: &str,
         url: &str,
@@ -929,6 +962,11 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
         force: bool,
         update_list: &[String],
     ) -> Result<&'ctx Path> {
+        // Serialize concurrent bender invocations operating on the same
+        // dependency. The lock covers both the bare database (touched via the
+        // `git_database_locked` calls below) and the working checkout.
+        let _lock = FsLock::acquire_exclusive(self.sess.dep_lock_path(name, url)).await?;
+
         #[derive(Eq, PartialEq)]
         enum CheckoutState {
             Clean,
@@ -944,7 +982,9 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
                     log::debug!("currently `{}` (want `{}`)", current, revision);
                     if current == revision {
                         CheckoutState::Clean
-                    } else if let Ok(db) = self.git_database(name, url, Some(false), None).await {
+                    } else if let Ok(db) =
+                        self.git_database_locked(name, url, Some(false), None).await
+                    {
                         if let Ok(remote) = local_git.clone().remote_url("origin").await {
                             if remote == db.path.to_str().unwrap() {
                                 CheckoutState::ToCheckout
@@ -1010,7 +1050,7 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
             let tag_name_1 = tag_name_0.clone();
             let tag_name_2 = tag_name_0.clone();
             let git = self
-                .git_database(name, url, Some(false), Some(revision))
+                .git_database_locked(name, url, Some(false), Some(revision))
                 .await?;
             match git
                 .clone()

--- a/src/src.rs
+++ b/src/src.rs
@@ -223,11 +223,11 @@ impl<'ctx> SourceGroup<'ctx> {
     ) -> IndexSet<String> {
         let mut result = packages.clone();
 
-        if let Some(x) = self.package {
-            if result.contains(x) {
-                result.extend(self.dependencies.iter().cloned());
-                result = &result - excludes;
-            }
+        if let Some(x) = self.package
+            && result.contains(x)
+        {
+            result.extend(self.dependencies.iter().cloned());
+            result = &result - excludes;
         }
 
         for file in &self.files {
@@ -425,10 +425,10 @@ pub struct FilteredSourceGroup<'ctx> {
 
 impl<'ctx> From<SourceGroup<'ctx>> for FilteredSourceGroup<'ctx> {
     fn from(group: SourceGroup<'ctx>) -> Self {
-        if group.override_files {
-            if let Some(pkg) = group.package {
-                Warnings::OverrideFilesIgnored(pkg.to_string()).emit();
-            }
+        if group.override_files
+            && let Some(pkg) = group.package
+        {
+            Warnings::OverrideFilesIgnored(pkg.to_string()).emit();
         }
         let include_dirs = group
             .include_dirs

--- a/src/src.rs
+++ b/src/src.rs
@@ -374,13 +374,13 @@ impl<'ctx> SourceGroup<'ctx> {
                         .include_dirs
                         .iter()
                         .cloned()
-                        .chain(grp.include_dirs.into_iter())
+                        .chain(grp.include_dirs)
                         .collect();
                     grp.defines = self
                         .defines
                         .iter()
                         .map(|(k, v)| (k.clone(), v.clone()))
-                        .chain(grp.defines.into_iter())
+                        .chain(grp.defines)
                         .collect();
                     grp.flatten_into(into);
                 }

--- a/tests/cli_regression.rs
+++ b/tests/cli_regression.rs
@@ -66,7 +66,7 @@ fn get_test_env() -> &'static (PathBuf, PathBuf) {
             std::fs::create_dir_all(&install_root).expect("Failed to create install dir");
 
             let status = SysCommand::new("cargo")
-                .args(&[
+                .args([
                     "install",
                     "--git",
                     "https://github.com/pulp-platform/bender",


### PR DESCRIPTION
- **Filesystem locks**: wrap `git_database` and `checkout_git` in a cross-process `flock` (`fs4`) keyed per dependency, so concurrent `bender` invocations against the same dep serialize safely. Locks live at `<database>/git/locks/` and are released by the kernel on process exit.
- **`db_dir` config field**: new optional setting that overrides only the bare-repo and lock paths, leaving checkouts under `database`. Lets a single shared `Bender.local` enable cross-project cache reuse without forcing per-project `workspace.checkout_dir`. Older bender versions silently ignore the field and fall back to per-project caches — safer than the legacy `database:`-only sharing recipe in mixed-version setups.
- **Clippy cleanup**: separate commit fixing pre-existing warnings (`collapsible_match`, redundant `.into_iter()`, `args(&[...])`). `cargo clippy --all-targets -- -D warnings` now passes.

Docs updated: `configuration.md` (new `db_dir` entry), `workflow/ci.md` (`db_dir` is now the recommended sharing recipe; retires the concurrent-runs caveat), `local.md`, `CHANGELOG.md`.
