### PR TITLE
Use shared clone for checkouts, dissociate on `bender clone`

### DIFF
--- a/src/cmd/clone.rs
+++ b/src/cmd/clone.rs
@@ -101,6 +101,27 @@ pub fn run(sess: &Session, path: &Path, args: &CloneArgs) -> Result<()> {
             if !command.unwrap().success() {
                 bail!("Copying {} failed", dep);
             }
+
+            // The checkout borrows its objects from the bare git database
+            // (cloned with `--shared`), so the copy is not yet self-contained.
+            // Absorb the borrowed objects into a local pack and drop the
+            // alternates link so the working copy is a standalone repository.
+            let dst = path.join(path_mod).join(dep);
+            if !SysCommand::new(&sess.config.git)
+                .arg("repack")
+                .arg("-a")
+                .arg("-d")
+                .current_dir(&dst)
+                .status()
+                .unwrap()
+                .success()
+            {
+                bail!(
+                    "git repack failed while detaching {} from the object cache",
+                    dep
+                );
+            }
+            let _ = std::fs::remove_file(dst.join(".git/objects/info/alternates"));
         }
 
         // rename and update git remotes for easier handling

--- a/src/sess.rs
+++ b/src/sess.rs
@@ -1101,6 +1101,7 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
                                 .arg("clone")
                                 .arg(git.path)
                                 .arg(path)
+                                .arg("--shared")
                                 .arg("--branch")
                                 .arg(tag_name_2)
                                 .arg("--progress")


### PR DESCRIPTION
Clone git checkouts with `--shared` so they borrow objects from the bare git database via alternates instead of copying the full object store, making checkouts faster and smaller on disk.

Since the resulting checkout is no longer self-contained, `bender clone` now repacks the copied working directory (`git repack -a -d`) and removes the alternates link so the cloned-out repository is standalone.