### PR TITLE
fix(sess): remove `.svh` files from verilog pattern list

### DIFF
--- a/src/sess.rs
+++ b/src/sess.rs
@@ -454,9 +454,7 @@ impl<'ctx> Session<'ctx> {
             .map(|file| match *file {
                 config::SourceFile::File(ref path) => {
                     let ty = match path.extension().and_then(std::ffi::OsStr::to_str) {
-                        Some("sv") | Some("v") | Some("vp") | Some("svh") => {
-                            Some(SourceType::Verilog)
-                        }
+                        Some("sv") | Some("v") | Some("vp") => Some(SourceType::Verilog),
                         Some("vhd") | Some("vhdl") => Some(SourceType::Vhdl),
                         _ => None,
                     };


### PR DESCRIPTION
Addresses https://github.com/pulp-platform/bender/issues/312 which was a regression in v0.32.0

This fixes the issues with cva6 that I had in gwaihir