### PR TITLE
Add `git_submodules` flag to control dependency submodule cloning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Unreleased
 ### Added
-- Add `git_submodules` config field and `--git-submodules <true|false>` flag (env `BENDER_GIT_SUBMODULES`) to control cloning of dependency submodules; defaults to `true`, the flag overrides the configured value in either direction (https://github.com/pulp-platform/bender/pull/PRNUM).
+- Add `git_submodules` config field and `--git-submodules <true|false>` flag (env `BENDER_GIT_SUBMODULES`) to control cloning of dependency submodules; defaults to `true`, the flag overrides the configured value in either direction (https://github.com/pulp-platform/bender/pull/314).
 
 ## 0.32.0 - 2026-06-05
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Add `git_submodules` config field and `--git-submodules <true|false>` flag (env `BENDER_GIT_SUBMODULES`) to control cloning of dependency submodules; defaults to `true`, the flag overrides the configured value in either direction (https://github.com/pulp-platform/bender/pull/PRNUM).
 
 ## 0.32.0 - 2026-06-05
 ### Breaking Changes

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -56,6 +56,14 @@ Enable or disable Git Large File Storage (LFS) support. Requires `git-lfs` to be
 - **Default:** `true`
 - **Example:** `git_lfs: false`
 
+### `git_submodules`
+Clone the git submodules of dependencies. Disabling this skips `git submodule update` during checkout, which can substantially speed up the initial dependency fetch when dependencies carry submodules (e.g. software or tooling) that are not needed for the hardware build. Disable it only when none of your dependencies reference sources that live inside a submodule.
+- **Config Key:** `git_submodules`
+- **CLI Flag:** `--git-submodules <true|false>` (overrides the configured value in either direction)
+- **Env Var:** `BENDER_GIT_SUBMODULES`
+- **Default:** `true`
+- **Example:** `git_submodules: false`
+
 ### `overrides`
 Forces specific dependencies to use a particular version or local path. This is primarily used in [`Bender.local`](./local.md) for development.
 - **Config Key:** `overrides`

--- a/book/src/dependencies.md
+++ b/book/src/dependencies.md
@@ -118,6 +118,8 @@ Cloning submodules is often the slowest part of fetching dependencies, and submo
 
 Only disable submodules when none of your dependencies reference sources that live inside a submodule.
 
+When submodules are disabled, Bender emits a warning for each dependency that carries submodules, listing the unchecked-out submodule paths and the `git submodule update --init --recursive` command to fetch them back into its checkout.
+
 ## Version Resolution and the Lockfile
 
 When you run `bender update`, Bender performs the following:

--- a/book/src/dependencies.md
+++ b/book/src/dependencies.md
@@ -109,7 +109,14 @@ Bender detects whether a dependency uses **Git Large File Storage (LFS)** via it
 
 ## Submodules
 
-If a dependency contains a `.gitmodules` file, Bender will automatically initialize and update its Git submodules recursively after checkout. No additional configuration is required.
+If a dependency contains a `.gitmodules` file, Bender initializes and updates its Git submodules recursively after checkout by default.
+
+Cloning submodules is often the slowest part of fetching dependencies, and submodules frequently hold software or tooling that is irrelevant to the hardware build. You can therefore disable submodule cloning:
+
+- Set `git_submodules: false` in your [configuration](./configuration.md#git_submodules) to skip submodules persistently for a project.
+- Pass `--git-submodules false` (or set `BENDER_GIT_SUBMODULES=false`) to skip them for a single invocation. The flag overrides the configured value in either direction.
+
+Only disable submodules when none of your dependencies reference sources that live inside a submodule.
 
 ## Version Resolution and the Lockfile
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,6 +61,15 @@ struct Cli {
     )]
     git_throttle: Option<usize>,
 
+    /// Clone the git submodules of dependencies [default: true]
+    #[arg(
+        long,
+        global = true,
+        help_heading = "Global Options",
+        env = "BENDER_GIT_SUBMODULES"
+    )]
+    git_submodules: Option<bool>,
+
     /// Suppresses specific warnings. Use `all` to suppress all warnings.
     #[arg(long, global = true, action = ArgAction::Append, help_heading = "Global Options", env = "BENDER_SUPPRESS_WARNINGS")]
     suppress: Vec<String>,
@@ -198,7 +207,13 @@ pub fn main() -> Result<()> {
     log::debug!("{:#?}", manifest);
 
     // Gather and parse the tool configuration.
-    let config = load_config(&root_dir, matches!(cli.command, Commands::Update(_)))?;
+    let mut config = load_config(&root_dir, matches!(cli.command, Commands::Update(_)))?;
+
+    // The `--git-submodules` CLI flag (or `BENDER_GIT_SUBMODULES`) takes
+    // precedence over the configuration files in both directions.
+    if let Some(v) = cli.git_submodules {
+        config.git_submodules = v;
+    }
     log::debug!("{:#?}", config);
 
     // Determine git throttle. The precedence is: CLI argument, env variable, config file, default (4).
@@ -518,6 +533,7 @@ fn load_config(from: &Path, warn_config_loaded: bool) -> Result<Config> {
         plugins: None,
         git_throttle: None,
         git_lfs: None,
+        git_submodules: None,
     };
     out = out.merge(default_cfg);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1630,6 +1630,8 @@ pub struct Config {
     pub git_throttle: Option<usize>,
     /// Enable git LFS support, requires git-lfs (default: true)
     pub git_lfs: bool,
+    /// Clone the git submodules of dependencies (default: true)
+    pub git_submodules: bool,
 }
 
 /// A partial configuration.
@@ -1649,6 +1651,8 @@ pub struct PartialConfig {
     pub git_throttle: Option<usize>,
     /// Enable git LFS support, requires git-lfs (default: true)
     pub git_lfs: Option<bool>,
+    /// Clone the git submodules of dependencies (default: true)
+    pub git_submodules: Option<bool>,
 }
 
 impl PartialConfig {
@@ -1698,6 +1702,11 @@ impl Merge for PartialConfig {
                 (Some(v1), Some(v2)) => Some(v1 | v2),
                 (None, None) => None,
             },
+            git_submodules: match (self.git_submodules, other.git_submodules) {
+                (Some(v), None) | (None, Some(v)) => Some(v),
+                (Some(v1), Some(v2)) => Some(v1 | v2),
+                (None, None) => None,
+            },
         }
     }
 }
@@ -1733,6 +1742,7 @@ impl Validate for PartialConfig {
             },
             git_throttle: self.git_throttle,
             git_lfs: self.git_lfs.unwrap_or(true),
+            git_submodules: self.git_submodules.unwrap_or(true),
         })
     }
 }

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -432,6 +432,20 @@ pub enum Warnings {
     #[error("Source group in package {} uses `override_files`, which is not supported in the simplified source output and will be ignored.", fmt_pkg!(.0))]
     #[diagnostic(code(W35))]
     OverrideFilesIgnored(String),
+
+    #[error(
+        "Git submodules are disabled, dependency {} has submodules that were not checked out:\n{}",
+        fmt_pkg!(.0),
+        .1.iter().map(|p| format!("  - {}", fmt_path!(p))).collect::<Vec<_>>().join("\n")
+    )]
+    #[diagnostic(
+        code(W36),
+        help(
+            "Re-run with `--git-submodules true` (or set `git_submodules: true` in the configuration), or run `git -C \"$(bender path {})\" submodule update --init --recursive` to fetch them manually.",
+            fmt_pkg!(.0)
+        )
+    )]
+    SubmodulesDisabled(String, Vec<String>),
 }
 
 #[derive(Error, Diagnostic, Debug, Clone)]

--- a/src/git.rs
+++ b/src/git.rs
@@ -326,6 +326,29 @@ impl<'ctx> Git<'ctx> {
         .wrap_err("Failed to check for LFS attributes.")?
     }
 
+    /// List the working-tree paths of the submodules declared in the
+    /// repository's `.gitmodules` file.
+    ///
+    /// `.gitmodules` is the authoritative source for what `git submodule update`
+    /// fetches: a submodule must have a `submodule.<name>.path` entry there to be
+    /// cloned. This mirrors how bender decides whether to run a submodule update
+    /// in the first place, namely by checking for the presence of `.gitmodules`.
+    pub async fn submodule_paths(self) -> Result<Vec<String>> {
+        let gitmodules = self.path.join(".gitmodules");
+        let content = tokio::fs::read_to_string(&gitmodules)
+            .await
+            .into_diagnostic()
+            .wrap_err_with(|| format!("Failed to read {:?}.", gitmodules))?;
+        Ok(content
+            .lines()
+            .filter_map(|line| {
+                let rest = line.trim_start().strip_prefix("path")?.trim_start();
+                let value = rest.strip_prefix('=')?.trim();
+                Some(value.to_string())
+            })
+            .collect())
+    }
+
     /// Fetch the tags and refs of a remote.
     pub async fn fetch(self, remote: &str, pb: Option<ProgressHandler>) -> Result<()> {
         self.clone()

--- a/src/sess.rs
+++ b/src/sess.rs
@@ -1219,7 +1219,7 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
                     Warnings::LfsDisabled(name.to_string()).emit();
                 }
             }
-            if path.join(".gitmodules").exists() {
+            if self.sess.config.git_submodules && path.join(".gitmodules").exists() {
                 let pb = Some(ProgressHandler::new(
                     self.sess.multiprogress.clone(),
                     GitProgressOps::Submodule,

--- a/src/sess.rs
+++ b/src/sess.rs
@@ -1219,25 +1219,33 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
                     Warnings::LfsDisabled(name.to_string()).emit();
                 }
             }
-            if self.sess.config.git_submodules && path.join(".gitmodules").exists() {
-                let pb = Some(ProgressHandler::new(
-                    self.sess.multiprogress.clone(),
-                    GitProgressOps::Submodule,
-                    name,
-                ));
-                local_git
-                    .clone()
-                    .spawn_with(
-                        move |c| {
-                            c.arg("submodule")
-                                .arg("update")
-                                .arg("--init")
-                                .arg("--recursive")
-                                .arg("--progress")
-                        },
-                        pb,
-                    )
-                    .await?;
+            if path.join(".gitmodules").exists() {
+                if self.sess.config.git_submodules {
+                    let pb = Some(ProgressHandler::new(
+                        self.sess.multiprogress.clone(),
+                        GitProgressOps::Submodule,
+                        name,
+                    ));
+                    local_git
+                        .clone()
+                        .spawn_with(
+                            move |c| {
+                                c.arg("submodule")
+                                    .arg("update")
+                                    .arg("--init")
+                                    .arg("--recursive")
+                                    .arg("--progress")
+                            },
+                            pb,
+                        )
+                        .await?;
+                } else {
+                    // Submodules were disabled via the `--git-submodules` flag,
+                    // so they are left unchecked out. Warn the user, listing the
+                    // affected submodules and how to fetch them back.
+                    let submodules = local_git.clone().submodule_paths().await?;
+                    Warnings::SubmodulesDisabled(name.to_string(), submodules).emit();
+                }
             }
         }
         Ok(path)


### PR DESCRIPTION
## What

Adds a `git_submodules` option to control whether Bender clones the Git submodules of dependencies.

- **Config field** `git_submodules` (default `true`), mirroring the existing `git_lfs` option — OR-merged across config layers, validated with `unwrap_or(true)`.
- **CLI flag** `--git-submodules <true|false>` (env `BENDER_GIT_SUBMODULES`), modelled on `--git-throttle`. It overrides the configured value in **either** direction.
- When disabled, the `git submodule update --init --recursive` step is skipped during checkout (along with its per-submodule progress bar).

## Why

`git submodule update --init --recursive` currently runs unconditionally on every checkout that has a `.gitmodules` file, and it is frequently the slowest part of the initial dependency fetch. In top-level hardware projects, dependency submodules often hold software or tooling that is irrelevant to the build, so cloning them is wasted work. This gives users an escape hatch — persistently via config, or per-invocation via the flag (e.g. in CI).

The default stays `true`, so existing behavior is unchanged unless explicitly opted out.

## Notes

- The flag intentionally **takes a value** rather than being a presence-only switch (like `--no-progress`). This keeps the door open to later widening the accepted values — e.g. selecting specific dependencies — without a breaking change to the CLI surface. The config field stays a plain `bool` for now; no enum is introduced yet.
- Per-dependency / selective submodule control was deliberately *not* implemented here. The cleaner long-term home for that granularity is producer-side (a dependency declaring which submodule paths it needs), since the consumer generally lacks that knowledge and it doesn't scale to transitive deps.
- Docs updated: `book/src/configuration.md` (config field reference) and `book/src/dependencies.md` (Submodules section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)