### PR TITLE
database: treat database as read-only after creation and use shared locks

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -28,7 +28,7 @@ The directory where Bender stores cloned and checked-out dependencies.
 - **Example:** `database: /var/cache/bender_dependencies`
 
 ### `db_dir`
-Optional override for the directory that holds bare git repositories and their lock files (i.e. `<db_dir>/git/db/` and `<db_dir>/git/locks/`). When set, it takes precedence over `database` (whether explicitly configured or left at its default) for these two paths only; the working-tree checkouts continue to follow `database` (or [`workspace.checkout_dir`](./manifest.md) in the project manifest). This makes it possible to share the heavy git data across projects on a persistent runner without also relocating per-project checkouts. See [Continuous Integration › Sharing the Database](./workflow/ci.md#sharing-the-database-across-runs-and-projects) for the recommended setup.
+Optional override for the directory that holds the bare git repositories and their lock files (both live under `<db_dir>/git/db/`, each lock file sitting next to the bare repo it guards). When set, it takes precedence over `database` (whether explicitly configured or left at its default) for this path only; the working-tree checkouts continue to follow `database` (or [`workspace.checkout_dir`](./manifest.md) in the project manifest). This makes it possible to share the heavy git data across projects on a persistent runner without also relocating per-project checkouts. See [Continuous Integration › Sharing the Database](./workflow/ci.md#sharing-the-database-across-runs-and-projects) for the recommended setup.
 - **Config Key:** `db_dir`
 - **Env Var:** `BENDER_DB_DIR` (used only when no configuration file sets `db_dir`; configuration files always take precedence).
 - **Default:** unset (falls back to `database`).

--- a/book/src/workflow/ci.md
+++ b/book/src/workflow/ci.md
@@ -95,7 +95,7 @@ Place a [`Bender.local`](../local.md) in a parent directory of your projects so 
 db_dir: /var/cache/bender_shared
 ```
 
-Every job on the runner now reuses the already-fetched Git data and serializes safely against concurrent jobs via per-dependency filesystem locks living next to the bare repos (`<db_dir>/git/locks/`).
+Every job on the runner now reuses the already-fetched Git data and serializes safely against concurrent jobs via per-dependency filesystem locks living next to the bare repos (`<db_dir>/git/db/`).
 
 If you'd rather not place a `Bender.local` on the runner at all, exporting `BENDER_DB_DIR=/var/cache/bender_shared` in the job environment has the same effect — any project that explicitly sets `db_dir` in its own configuration overrides the env var.
 

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -3,58 +3,62 @@
 //! Cross-process filesystem advisory locks.
 //!
 //! Bender uses these to coordinate concurrent invocations against the same git
-//! database. The lock is taken on a sentinel file in
-//! `<database>/git/locks/<name>-<hash>.lock`: writers (database initialization
-//! and fetches) acquire it exclusively, while readers (version resolution and
-//! checkouts, which never mutate the database) acquire it shared so they can
-//! proceed in parallel. The lock is released automatically when the [`FsLock`]
-//! guard is dropped.
+//! database. The lock is taken on a sentinel file kept as a sibling of the
+//! resource it guards -- `<database>/git/db/<name>-<hash>.lock` for a bare
+//! database, or `<checkout>.lock` for a working-tree checkout: writers
+//! (database initialization and fetches) acquire it exclusively, while readers
+//! (version resolution and checkouts, which never mutate the database) acquire
+//! it shared so they can proceed in parallel. The lock is released
+//! automatically when the [`FsLockGuard`] is dropped.
 
 #![deny(missing_docs)]
 
 use std::fs::{File, OpenOptions, TryLockError};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use miette::{Context as _, IntoDiagnostic as _};
 
 use crate::Result;
 
-/// An exclusive, cross-process advisory lock held on a sentinel file.
-///
-/// The lock is released when this guard is dropped (or when the process exits).
+/// A cross-process advisory lock identified by a sentinel file path.
 pub struct FsLock {
-    file: Option<File>,
     path: PathBuf,
 }
 
 impl FsLock {
-    /// Acquire an exclusive (writer) lock on `path`, creating the file if
-    /// missing.
+    /// Create a lock on the sentinel file at `path`.
+    ///
+    /// This does not touch the filesystem; the file is created and locked when
+    /// [`acquire_exclusive`](Self::acquire_exclusive) or
+    /// [`acquire_shared`](Self::acquire_shared) is called.
+    pub fn new(path: PathBuf) -> Self {
+        FsLock { path }
+    }
+
+    /// Acquire an exclusive (writer) lock, creating the file if missing.
     ///
     /// Use this for operations that mutate the git database (initialization or
     /// fetching). See [`acquire`](Self::acquire) for the blocking behavior.
-    pub async fn acquire_exclusive(path: PathBuf) -> Result<Self> {
-        Self::acquire(path, true).await
+    pub async fn acquire_exclusive(&self) -> Result<FsLockGuard> {
+        self.acquire(true).await
     }
 
-    /// Acquire a shared (reader) lock on `path`, creating the file if missing.
+    /// Acquire a shared (reader) lock, creating the file if missing.
     ///
     /// Multiple processes may hold a shared lock simultaneously; a shared lock
     /// only excludes exclusive lockers. Use this for read-only access to the
     /// git database, such as resolving versions or creating a checkout. This
     /// is what lets concurrent bender invocations check out in parallel against
     /// a shared, pre-populated database.
-    pub async fn acquire_shared(path: PathBuf) -> Result<Self> {
-        Self::acquire(path, false).await
+    pub async fn acquire_shared(&self) -> Result<FsLockGuard> {
+        self.acquire(false).await
     }
 
-    /// Acquire a lock on `path`, creating the file if missing.
+    /// Acquire the lock, creating the file if missing.
     ///
-    /// If the lock is contended, an info message is logged so the user can see
-    /// why bender is waiting, and the call then blocks until the lock is
-    /// available. The actual lock acquisition runs on a blocking worker so it
-    /// does not stall the tokio runtime.
-    async fn acquire(path: PathBuf, exclusive: bool) -> Result<Self> {
+    /// If the lock is contended, the call blocks until the lock is available.
+    async fn acquire(&self, exclusive: bool) -> Result<FsLockGuard> {
+        let path = self.path.clone();
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)
                 .into_diagnostic()
@@ -69,7 +73,6 @@ impl FsLock {
             .into_diagnostic()
             .wrap_err_with(|| format!("Failed to open lock file {:?}.", path))?;
 
-        let path_for_blocking = path.clone();
         let file = tokio::task::spawn_blocking(move || -> Result<File> {
             let try_lock = if exclusive {
                 file.try_lock()
@@ -79,44 +82,39 @@ impl FsLock {
             match try_lock {
                 Ok(()) => Ok(file),
                 Err(TryLockError::WouldBlock) => {
-                    log::info!("waiting for lock on {:?}", path_for_blocking);
+                    log::info!("waiting for lock on {:?}", path);
                     let blocking_lock = if exclusive {
                         file.lock()
                     } else {
                         file.lock_shared()
                     };
-                    blocking_lock.into_diagnostic().wrap_err_with(|| {
-                        format!("Failed to acquire lock on {:?}.", path_for_blocking)
-                    })?;
+                    blocking_lock
+                        .into_diagnostic()
+                        .wrap_err_with(|| format!("Failed to acquire lock on {:?}.", path))?;
                     Ok(file)
                 }
                 Err(TryLockError::Error(e)) => Err(e)
                     .into_diagnostic()
-                    .wrap_err_with(|| format!("Failed to try-lock {:?}.", path_for_blocking)),
+                    .wrap_err_with(|| format!("Failed to try-lock {:?}.", path)),
             }
         })
         .await
         .into_diagnostic()
         .wrap_err("Lock acquisition task panicked.")??;
 
-        Ok(FsLock {
-            file: Some(file),
-            path,
-        })
-    }
-
-    /// The path of the lock file.
-    pub fn path(&self) -> &Path {
-        &self.path
+        Ok(FsLockGuard { file })
     }
 }
 
-impl Drop for FsLock {
+/// A held [`FsLock`], released when this guard is dropped (or the process exits).
+pub struct FsLockGuard {
+    file: File,
+}
+
+impl Drop for FsLockGuard {
     fn drop(&mut self) {
-        if let Some(file) = self.file.take() {
-            // Best-effort: errors here are not actionable, and the OS releases
-            // the lock automatically when the file handle closes.
-            let _ = file.unlock();
-        }
+        // Best-effort: errors here are not actionable, and the OS releases the
+        // lock automatically when the file handle closes.
+        let _ = self.file.unlock();
     }
 }

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -2,10 +2,13 @@
 
 //! Cross-process filesystem advisory locks.
 //!
-//! Bender uses these to serialize concurrent invocations against the same git
-//! database and checkout. The lock is taken on a sentinel file in
-//! `<database>/git/locks/<name>-<hash>.lock` and released automatically when
-//! the [`FsLock`] guard is dropped.
+//! Bender uses these to coordinate concurrent invocations against the same git
+//! database. The lock is taken on a sentinel file in
+//! `<database>/git/locks/<name>-<hash>.lock`: writers (database initialization
+//! and fetches) acquire it exclusively, while readers (version resolution and
+//! checkouts, which never mutate the database) acquire it shared so they can
+//! proceed in parallel. The lock is released automatically when the [`FsLock`]
+//! guard is dropped.
 
 #![deny(missing_docs)]
 
@@ -25,13 +28,33 @@ pub struct FsLock {
 }
 
 impl FsLock {
-    /// Acquire an exclusive lock on `path`, creating the file if missing.
+    /// Acquire an exclusive (writer) lock on `path`, creating the file if
+    /// missing.
+    ///
+    /// Use this for operations that mutate the git database (initialization or
+    /// fetching). See [`acquire`](Self::acquire) for the blocking behavior.
+    pub async fn acquire_exclusive(path: PathBuf) -> Result<Self> {
+        Self::acquire(path, true).await
+    }
+
+    /// Acquire a shared (reader) lock on `path`, creating the file if missing.
+    ///
+    /// Multiple processes may hold a shared lock simultaneously; a shared lock
+    /// only excludes exclusive lockers. Use this for read-only access to the
+    /// git database, such as resolving versions or creating a checkout. This
+    /// is what lets concurrent bender invocations check out in parallel against
+    /// a shared, pre-populated database.
+    pub async fn acquire_shared(path: PathBuf) -> Result<Self> {
+        Self::acquire(path, false).await
+    }
+
+    /// Acquire a lock on `path`, creating the file if missing.
     ///
     /// If the lock is contended, an info message is logged so the user can see
     /// why bender is waiting, and the call then blocks until the lock is
     /// available. The actual lock acquisition runs on a blocking worker so it
     /// does not stall the tokio runtime.
-    pub async fn acquire_exclusive(path: PathBuf) -> Result<Self> {
+    async fn acquire(path: PathBuf, exclusive: bool) -> Result<Self> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)
                 .into_diagnostic()
@@ -48,11 +71,21 @@ impl FsLock {
 
         let path_for_blocking = path.clone();
         let file = tokio::task::spawn_blocking(move || -> Result<File> {
-            match file.try_lock() {
+            let try_lock = if exclusive {
+                file.try_lock()
+            } else {
+                file.try_lock_shared()
+            };
+            match try_lock {
                 Ok(()) => Ok(file),
                 Err(TryLockError::WouldBlock) => {
                     log::info!("waiting for lock on {:?}", path_for_blocking);
-                    file.lock().into_diagnostic().wrap_err_with(|| {
+                    let blocking_lock = if exclusive {
+                        file.lock()
+                    } else {
+                        file.lock_shared()
+                    };
+                    blocking_lock.into_diagnostic().wrap_err_with(|| {
                         format!("Failed to acquire lock on {:?}.", path_for_blocking)
                     })?;
                     Ok(file)

--- a/src/sess.rs
+++ b/src/sess.rs
@@ -575,6 +575,21 @@ impl<'ctx> Session<'ctx> {
             .join(format!("{}.lock", key))
     }
 
+    /// Path of the cross-process advisory lock file for a working-tree
+    /// checkout.
+    ///
+    /// Held exclusively across `checkout_git` so that two bender invocations
+    /// that resolve to the same checkout directory -- e.g. two runs against the
+    /// same project root -- cannot interleave their `remove_dir_all` / `git
+    /// clone` / `git checkout` operations and corrupt the working tree. The
+    /// lock file lives as a sibling of the checkout directory so it travels
+    /// with the project, independent of where the bare database is stored.
+    pub fn checkout_lock_path(&self, checkout_path: &Path) -> PathBuf {
+        let mut p = checkout_path.as_os_str().to_owned();
+        p.push(".lock");
+        PathBuf::from(p)
+    }
+
     /// The directory under which bare git databases and lock files live.
     ///
     /// Uses `db_dir` if configured (the recommended way to share bare repos
@@ -1088,6 +1103,17 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
         force: bool,
         update_list: &[String],
     ) -> Result<&'ctx Path> {
+        // Serialize concurrent bender invocations that resolve to the same
+        // checkout directory -- typically two runs against the same project
+        // root. Without this, the shared db lock taken below does not protect
+        // us: shared lockers don't block each other, so two simultaneous
+        // `checkout_git` calls could interleave `remove_dir_all`, `git clone`,
+        // and `git checkout` on the same working tree and corrupt it. The lock
+        // is per checkout path, so unrelated deps (and the same dep across
+        // different projects, which resolve to distinct paths) still run in
+        // parallel.
+        let _checkout_lock = FsLock::acquire_exclusive(self.sess.checkout_lock_path(path)).await?;
+
         // Resolve (and, if necessary, initialize) the bare database before
         // taking the lock we hold across the checkout. A checkout reads from the
         // database (via `git clone --shared`) but never writes to it, so a

--- a/src/sess.rs
+++ b/src/sess.rs
@@ -1224,7 +1224,16 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
             }
             // Check if the revision is reachable from any upstream branch or
             // tag. If not, warn that the commit may have been removed by a
-            // force-push.
+            // force-push. Synthetic `bender-tmp-*` tags are excluded: they are
+            // created by `dependency_versions` (and may persist in databases
+            // populated by older bender versions from the old checkout flow),
+            // and they do not represent upstream tracking.
+            //
+            // TODO: drop this filter once `bender-tmp-*` tags are either no
+            // longer created (e.g. by replacing the `rev-list --all` use in
+            // `dependency_versions` with a hash-based reachability check) or
+            // swept after use; the filter is here to remain correct on
+            // databases that still contain such tags.
             let revision_owned = revision.to_string();
             if let Ok(ref_output) = git
                 .clone()
@@ -1240,7 +1249,7 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
                     None,
                 )
                 .await
-                && ref_output.trim().is_empty()
+                && !ref_output.lines().any(|line| !line.contains("bender-tmp-"))
             {
                 Warnings::RevisionNotOnUpstream(revision.to_string(), name.to_string()).emit();
             }

--- a/src/sess.rs
+++ b/src/sess.rs
@@ -562,8 +562,11 @@ impl<'ctx> Session<'ctx> {
 
     /// Path of the cross-process advisory lock file for a git dependency.
     ///
-    /// The same file guards both the bare database under `git/db/` and the
-    /// working checkout under `git/checkouts/` for this dependency.
+    /// This single file coordinates access to the bare database under
+    /// `git/db/` for this dependency. Writers (database initialization and
+    /// fetches) take it exclusively; readers (version resolution and checkouts)
+    /// take it shared, so concurrent invocations against a populated database
+    /// do not serialize.
     pub fn dep_lock_path(&self, name: &str, url: &str) -> PathBuf {
         let key = self.git_db_name(name, url);
         self.db_parent()
@@ -733,6 +736,13 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
             ));
             git.clone()
                 .spawn_with(|c| c.arg("init").arg("--bare"), None)
+                .await?;
+            // Disable automatic garbage collection on the shared database.
+            // Checkouts created with `git clone --shared` borrow objects from
+            // this database via `objects/info/alternates`, so pruning here
+            // could corrupt live checkouts that reference those objects.
+            git.clone()
+                .spawn_with(|c| c.arg("config").arg("gc.auto").arg("0"), None)
                 .await?;
             git.clone()
                 .spawn_with(|c| c.arg("remote").arg("add").arg("origin").arg(url), None)
@@ -951,6 +961,83 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
         }
     }
 
+    /// Fetch a single commit by hash into the git database.
+    ///
+    /// This recovers a commit that was force-pushed off every branch and tag
+    /// upstream (so it is not advertised and a normal fetch does not retrieve
+    /// it) but remains reachable on the server and thus fetchable by hash. The
+    /// fetch mutates the database, so the exclusive lock is taken for it. The
+    /// fetch itself is best-effort -- not every server allows fetching an
+    /// unadvertised commit by hash -- so its result is ignored; the caller
+    /// verifies whether the commit became available.
+    async fn fetch_revision_by_hash(
+        &'io self,
+        name: &str,
+        url: &str,
+        revision: &str,
+    ) -> Result<()> {
+        let _wlock = FsLock::acquire_exclusive(self.sess.dep_lock_path(name, url)).await?;
+        let git = self
+            .git_database_locked(name, url, Some(false), None)
+            .await?;
+        let pb = Some(ProgressHandler::new(
+            self.sess.multiprogress.clone(),
+            GitProgressOps::Fetch,
+            name,
+        ));
+        let revision_owned = revision.to_string();
+        let _ = git
+            .clone()
+            .spawn_with(
+                move |c| {
+                    c.arg("fetch")
+                        .arg("origin")
+                        .arg(revision_owned)
+                        .arg("--progress")
+                },
+                pb,
+            )
+            .await;
+        Ok(())
+    }
+
+    /// Check out `revision` in the working copy managed by `local_git`.
+    ///
+    /// LFS smudge filters are disabled here; LFS content is pulled separately
+    /// after the checkout. Returns an error if the revision cannot be checked
+    /// out (e.g. its objects are not available in the database).
+    async fn checkout_revision(
+        &'io self,
+        local_git: &Git<'ctx>,
+        revision: &str,
+        name: &str,
+    ) -> Result<String> {
+        let pb = Some(ProgressHandler::new(
+            self.sess.multiprogress.clone(),
+            GitProgressOps::Checkout,
+            name,
+        ));
+        let revision_owned = revision.to_string();
+        local_git
+            .clone()
+            .spawn_with(
+                move |c| {
+                    c.arg("-c")
+                        .arg("filter.lfs.smudge=")
+                        .arg("-c")
+                        .arg("filter.lfs.process=")
+                        .arg("-c")
+                        .arg("filter.lfs.required=false")
+                        .arg("checkout")
+                        .arg(revision_owned)
+                        .arg("--force")
+                        .arg("--progress")
+                },
+                pb,
+            )
+            .await
+    }
+
     /// Ensure that a proper git checkout exists.
     ///
     /// If the directory is not a proper git repository, it is deleted and
@@ -964,10 +1051,13 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
         force: bool,
         update_list: &[String],
     ) -> Result<&'ctx Path> {
-        // Serialize concurrent bender invocations operating on the same
-        // dependency. The lock covers both the bare database (touched via the
-        // `git_database_locked` calls below) and the working checkout.
-        let _lock = FsLock::acquire_exclusive(self.sess.dep_lock_path(name, url)).await?;
+        // A checkout reads from the shared bare database (via `git clone
+        // --shared`) but never writes to it, so a shared lock is enough and
+        // lets concurrent invocations check out in parallel against a warm,
+        // pre-populated database. The only writer path is the fallback fetch
+        // below (when the locked revision is missing from the database), which
+        // briefly drops this lock and takes an exclusive one of its own.
+        let mut db_lock = Some(FsLock::acquire_shared(self.sess.dep_lock_path(name, url)).await?);
 
         #[derive(Eq, PartialEq)]
         enum CheckoutState {
@@ -1045,65 +1135,38 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
 
         // Perform the checkout if necessary.
         if clear != CheckoutState::Clean {
-            // First generate a tag to be cloned in the database. This is
-            // necessary since `git clone` does not accept commits, but only
-            // branches or tags for shallow clones.
-            let tag_name_0 = format!("bender-tmp-{}", revision);
-            let tag_name_1 = tag_name_0.clone();
-            let tag_name_2 = tag_name_0.clone();
-            let git = self
-                .git_database_locked(name, url, Some(false), Some(revision))
+            // Ensure the requested revision is present in the database. The
+            // database is normally already populated, so this is a read-only
+            // check under the shared lock. If the revision is missing (e.g. the
+            // cached database predates the locked commit), it must be fetched,
+            // which mutates the database: drop the shared lock, fetch via
+            // `git_database` (which locks exclusively), then re-take the shared
+            // lock and continue.
+            let mut git = self
+                .git_database_locked(name, url, Some(false), None)
                 .await?;
-            match git
+            let revision_check = revision.to_string();
+            let have_commit = git
                 .clone()
                 .spawn_with(
                     move |c| {
-                        c.arg("tag")
-                            .arg(tag_name_0)
-                            .arg(revision)
-                            .arg("--force")
-                            .arg("--no-sign")
+                        c.arg("cat-file")
+                            .arg("-e")
+                            .arg(format!("{}^{{commit}}", revision_check))
                     },
                     None,
                 )
                 .await
-            {
-                Ok(r) => Ok(r),
-                Err(_cause) => {
-                    log::debug!("failed to tag commit {:?}, attempting fetch.", _cause);
-                    let pb = Some(ProgressHandler::new(
-                        self.sess.multiprogress.clone(),
-                        GitProgressOps::Checkout,
-                        name,
-                    ));
-                    // Attempt to fetch from remote and retry, as commits seem unavailable.
-                    git.clone()
-                        .spawn_with(move |c| c.arg("fetch").arg("--all").arg("--progress"), pb)
-                        .await?;
-                    git.clone()
-                        .spawn_with(
-                            move |c| {
-                                c.arg("tag")
-                                    .arg(tag_name_1)
-                                    .arg(revision)
-                                    .arg("--force")
-                                    .arg("--no-sign")
-                            },
-                            None,
-                        )
-                        .await
-                        .map_err(|cause| {
-                            Error::from(SessionErrors::LockedRevisionCheckout(
-                                revision.to_string(),
-                                name.to_string(),
-                                cause.into(),
-                            ))
-                        })
-                }
-            }?;
+                .is_ok();
+            if !have_commit {
+                log::debug!("revision {} not in database, fetching.", revision);
+                drop(db_lock.take());
+                git = self.git_database(name, url, Some(true), None).await?;
+                db_lock = Some(FsLock::acquire_shared(self.sess.dep_lock_path(name, url)).await?);
+            }
             // Check if the revision is reachable from any upstream branch or
-            // tag (excluding synthetic bender-tmp-* tags). If not, warn that
-            // the commit may have been removed by a force-push.
+            // tag. If not, warn that the commit may have been removed by a
+            // force-push.
             let revision_owned = revision.to_string();
             if let Ok(ref_output) = git
                 .clone()
@@ -1119,11 +1182,9 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
                     None,
                 )
                 .await
+                && ref_output.trim().is_empty()
             {
-                let is_tracked = ref_output.lines().any(|line| !line.contains("bender-tmp-"));
-                if !is_tracked {
-                    Warnings::RevisionNotOnUpstream(revision.to_string(), name.to_string()).emit();
-                }
+                Warnings::RevisionNotOnUpstream(revision.to_string(), name.to_string()).emit();
             }
             if clear == CheckoutState::ToClone {
                 let pb = Some(ProgressHandler::new(
@@ -1131,6 +1192,11 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
                     GitProgressOps::Checkout,
                     name,
                 ));
+                // Clone the working tree from the database, borrowing its
+                // objects via `--shared` (alternates) so nothing is copied and
+                // the database is left untouched. `--no-checkout` keeps the
+                // worktree empty so the exact revision can be checked out next;
+                // no temporary tag in the database is needed.
                 git.clone()
                     .spawn_with(
                         move |c| {
@@ -1144,8 +1210,7 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
                                 .arg(git.path)
                                 .arg(path)
                                 .arg("--shared")
-                                .arg("--branch")
-                                .arg(tag_name_2)
+                                .arg("--no-checkout")
                                 .arg("--progress")
                         },
                         pb,
@@ -1170,29 +1235,37 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
                         pb,
                     )
                     .await?;
-                let pb = Some(ProgressHandler::new(
-                    self.sess.multiprogress.clone(),
-                    GitProgressOps::Checkout,
-                    name,
-                ));
-                local_git
-                    .clone()
-                    .spawn_with(
-                        move |c| {
-                            c.arg("-c")
-                                .arg("filter.lfs.smudge=")
-                                .arg("-c")
-                                .arg("filter.lfs.process=")
-                                .arg("-c")
-                                .arg("filter.lfs.required=false")
-                                .arg("checkout")
-                                .arg(tag_name_2)
-                                .arg("--force")
-                                .arg("--progress")
-                        },
-                        pb,
-                    )
-                    .await?;
+            }
+
+            // Check out the exact revision in the working copy. The object is
+            // normally available from the database via the `--shared`
+            // alternates link. If the checkout fails the commit is missing from
+            // the database -- typically because it was force-pushed off every
+            // branch upstream, so a normal fetch of all branches and tags does
+            // not retrieve it. Such a commit can still be fetched directly by
+            // hash (as long as it remains reachable on the server), so fetch it
+            // into the database by hash and retry once before giving up.
+            if self
+                .checkout_revision(&local_git, revision, name)
+                .await
+                .is_err()
+            {
+                log::debug!(
+                    "checkout of {} failed, fetching the commit by hash and retrying.",
+                    revision
+                );
+                drop(db_lock.take());
+                self.fetch_revision_by_hash(name, url, revision).await?;
+                db_lock = Some(FsLock::acquire_shared(self.sess.dep_lock_path(name, url)).await?);
+                self.checkout_revision(&local_git, revision, name)
+                    .await
+                    .map_err(|cause| {
+                        Error::from(SessionErrors::LockedRevisionCheckout(
+                            revision.to_string(),
+                            name.to_string(),
+                            cause.into(),
+                        ))
+                    })?;
             }
             // Check if the repo uses LFS attributes
             if local_git.clone().uses_lfs_attributes().await? {
@@ -1248,6 +1321,8 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
                 }
             }
         }
+        // Hold the database lock until the checkout is fully materialized.
+        drop(db_lock);
         Ok(path)
     }
 

--- a/src/sess.rs
+++ b/src/sess.rs
@@ -770,6 +770,13 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
             DbAction::Fetch => {
                 log::info!("fetching updates for {} from {}", name, url);
                 self.sess.stats.num_database_fetch.increment();
+                // Disable automatic garbage collection on the shared database
+                // (see init path for rationale). Idempotent and re-applied here
+                // so databases initialized by older bender versions also gain
+                // the setting on their next fetch.
+                git.clone()
+                    .spawn_with(|c| c.arg("config").arg("gc.auto").arg("0"), None)
+                    .await?;
                 // The progress bar object for fetching.
                 let pb = Some(ProgressHandler::new(
                     self.sess.multiprogress.clone(),

--- a/src/sess.rs
+++ b/src/sess.rs
@@ -1212,16 +1212,16 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
                 Warnings::RevisionNotOnUpstream(revision.to_string(), name.to_string()).emit();
             }
             if clear == CheckoutState::ToClone {
-                let pb = Some(ProgressHandler::new(
-                    self.sess.multiprogress.clone(),
-                    GitProgressOps::Checkout,
-                    name,
-                ));
                 // Clone the working tree from the database, borrowing its
                 // objects via `--shared` (alternates) so nothing is copied and
                 // the database is left untouched. `--no-checkout` keeps the
                 // worktree empty so the exact revision can be checked out next;
-                // no temporary tag in the database is needed.
+                // no temporary tag in the database is needed. This step
+                // transfers no objects and writes no working-tree files, so it
+                // runs without its own progress handler: the user-facing
+                // progress and finish line come from the checkout below, and a
+                // separate handler here would report the dependency as "Checked
+                // out" twice.
                 git.clone()
                     .spawn_with(
                         move |c| {
@@ -1236,9 +1236,8 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
                                 .arg(path)
                                 .arg("--shared")
                                 .arg("--no-checkout")
-                                .arg("--progress")
                         },
-                        pb,
+                        None,
                     )
                     .await?;
             } else if clear == CheckoutState::ToCheckout {

--- a/src/sess.rs
+++ b/src/sess.rs
@@ -599,6 +599,16 @@ pub struct SessionIo<'sess, 'ctx: 'sess> {
     git_versions: Mutex<IndexMap<PathBuf, GitVersions<'ctx>>>,
 }
 
+/// What accessing a dependency's git database requires.
+enum DbAction {
+    /// The database exists and is up to date; only read access is needed.
+    Ready,
+    /// The database does not exist yet and must be initialized and fetched.
+    Init,
+    /// The database exists but must be fetched to pick up upstream updates.
+    Fetch,
+}
+
 impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
     /// Create a new session wrapper.
     pub fn new(sess: &'sess Session<'ctx>) -> SessionIo<'sess, 'ctx> {
@@ -666,12 +676,19 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
         }
     }
 
-    /// Access the git database for a dependency.
+    /// Access the git database for a dependency, creating or updating it as
+    /// needed.
     ///
-    /// Acquires the per-dependency filesystem lock and delegates to
-    /// [`git_database_locked`]. Callers that already hold the lock for this
-    /// dependency should call [`git_database_locked`] directly to avoid
-    /// deadlocking.
+    /// Locking is fine-grained. The common case -- the database already exists
+    /// and is current -- only takes a shared lock, so concurrent read-only
+    /// callers run in parallel instead of serializing. Only when an
+    /// initialization or fetch is actually required is the lock escalated to
+    /// exclusive, and the database state is re-checked under it in case another
+    /// process performed the work while we were briefly unlocked. The lock is
+    /// released before returning; the returned handle is used for read-only
+    /// access. Callers that themselves mutate (e.g. a checkout holding a
+    /// long-lived shared lock and fetching on a fallback path) manage their own
+    /// locking around this call.
     async fn git_database(
         &'io self,
         name: &str,
@@ -679,33 +696,123 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
         force_fetch: Option<bool>,
         fetch_ref: Option<&str>,
     ) -> Result<Git<'ctx>> {
-        let _lock = FsLock::acquire_exclusive(self.sess.dep_lock_path(name, url)).await?;
-        self.git_database_locked(name, url, force_fetch, fetch_ref)
-            .await
-    }
-
-    /// Access the git database for a dependency, assuming the per-dependency
-    /// filesystem lock is already held by the caller.
-    ///
-    /// If the database does not exist, it is created. If the database has not
-    /// been updated recently, the remote is fetched.
-    async fn git_database_locked(
-        &'io self,
-        name: &str,
-        url: &str,
-        force_fetch: Option<bool>,
-        fetch_ref: Option<&str>,
-    ) -> Result<Git<'ctx>> {
+        self.sess.stats.num_calls_git_database.increment();
         // TODO: Make the assembled future shared and keep it in a lookup table.
         //       Then use that table to return the future if it already exists.
         //       This ensures that the gitdb is setup only once, and makes the
         //       whole process faster for later calls.
-        self.sess.stats.num_calls_git_database.increment();
+        let lock_path = self.sess.dep_lock_path(name, url);
 
+        // Fast path: under a shared lock, check whether the database is already
+        // present and up to date. If so, nothing has to be mutated and we can
+        // return right away, letting concurrent readers run in parallel.
+        let shared = FsLock::acquire_shared(lock_path.clone()).await?;
+        let (git, action) = self.git_database_action(name, url, force_fetch)?;
+        if let DbAction::Ready = action {
+            return Ok(git);
+        }
+        drop(shared);
+
+        // A mutation (initialization or fetch) is required. Take the exclusive
+        // lock and re-evaluate: another process may have completed the work
+        // while we were briefly unlocked, in which case there is nothing to do.
+        let _exclusive = FsLock::acquire_exclusive(lock_path).await?;
+        let (git, action) = self.git_database_action(name, url, force_fetch)?;
+        match action {
+            DbAction::Ready => Ok(git),
+            DbAction::Init => {
+                ensure!(
+                    !self.sess.local_only,
+                    help = "Re-run without `--local`, or provide a local path dependency.",
+                    "Cannot initialize git dependency while `--local` is enabled."
+                );
+                log::info!("initializing git database for {} from {}", name, url);
+                self.sess.stats.num_database_init.increment();
+                // The progress bar object for cloning. We only use it for the
+                // last fetch operation, which is the only network operation here.
+                let pb = Some(ProgressHandler::new(
+                    self.sess.multiprogress.clone(),
+                    GitProgressOps::Clone,
+                    name,
+                ));
+                git.clone()
+                    .spawn_with(|c| c.arg("init").arg("--bare"), None)
+                    .await?;
+                // Disable automatic garbage collection on the shared database.
+                // Checkouts created with `git clone --shared` borrow objects from
+                // this database via `objects/info/alternates`, so pruning here
+                // could corrupt live checkouts that reference those objects.
+                git.clone()
+                    .spawn_with(|c| c.arg("config").arg("gc.auto").arg("0"), None)
+                    .await?;
+                git.clone()
+                    .spawn_with(|c| c.arg("remote").arg("add").arg("origin").arg(url), None)
+                    .await?;
+                git.clone()
+                    .fetch("origin", pb)
+                    .and_then(|_| async {
+                        if let Some(reference) = fetch_ref {
+                            git.clone().fetch_ref("origin", reference, None).await
+                        } else {
+                            Ok(())
+                        }
+                    })
+                    .await
+                    .map_err(move |cause| {
+                        Error::from(SessionErrors::GitDatabaseAccess(
+                            "initialize",
+                            url.contains("git@"),
+                            cause.into(),
+                        ))
+                    })
+                    .map(move |_| git)
+            }
+            DbAction::Fetch => {
+                log::info!("fetching updates for {} from {}", name, url);
+                self.sess.stats.num_database_fetch.increment();
+                // The progress bar object for fetching.
+                let pb = Some(ProgressHandler::new(
+                    self.sess.multiprogress.clone(),
+                    GitProgressOps::Fetch,
+                    name,
+                ));
+                git.clone()
+                    .fetch("origin", pb)
+                    .and_then(|_| async {
+                        if let Some(reference) = fetch_ref {
+                            git.clone().fetch_ref("origin", reference, None).await
+                        } else {
+                            Ok(())
+                        }
+                    })
+                    .await
+                    .map_err(move |cause| {
+                        Error::from(SessionErrors::GitDatabaseAccess(
+                            "update",
+                            url.contains("git@"),
+                            cause.into(),
+                        ))
+                    })
+                    .map(move |_| git)
+            }
+        }
+    }
+
+    /// Locate the bare git database for a dependency and decide what, if
+    /// anything, has to be done to bring it up to date.
+    ///
+    /// This only inspects the database (creating its directory if missing); it
+    /// never mutates git objects, so it is safe to evaluate under a shared lock.
+    /// The fetch decision mirrors `force_fetch`: `Some(true)` always fetches,
+    /// `Some(false)` never fetches, and `None` fetches only if the manifest has
+    /// been modified since the last fetch.
+    fn git_database_action(
+        &'io self,
+        name: &str,
+        url: &str,
+        force_fetch: Option<bool>,
+    ) -> Result<(Git<'ctx>, DbAction)> {
         let db_name = self.sess.git_db_name(name, url);
-
-        // Determine the location of the git database and create it if its does
-        // not yet exist.
         let db_dir = self.sess.db_parent().join("git").join("db").join(db_name);
         let db_dir = self.sess.intern_path(db_dir);
         std::fs::create_dir_all(db_dir)
@@ -716,57 +823,9 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
             &self.sess.config.git,
             self.sess.git_throttle.clone(),
         );
-
-        // Either initialize the repository or update it if needed.
-        if !db_dir.join("config").exists() {
-            ensure!(
-                !self.sess.local_only,
-                help = "Re-run without `--local`, or provide a local path dependency.",
-                "Cannot initialize git dependency while `--local` is enabled."
-            );
-            // Initialize.
-            log::info!("initializing git database for {} from {}", name, url);
-            self.sess.stats.num_database_init.increment();
-            // The progress bar object for cloning. We only use it for the
-            // last fetch operation, which is the only network operation here.
-            let pb = Some(ProgressHandler::new(
-                self.sess.multiprogress.clone(),
-                GitProgressOps::Clone,
-                name,
-            ));
-            git.clone()
-                .spawn_with(|c| c.arg("init").arg("--bare"), None)
-                .await?;
-            // Disable automatic garbage collection on the shared database.
-            // Checkouts created with `git clone --shared` borrow objects from
-            // this database via `objects/info/alternates`, so pruning here
-            // could corrupt live checkouts that reference those objects.
-            git.clone()
-                .spawn_with(|c| c.arg("config").arg("gc.auto").arg("0"), None)
-                .await?;
-            git.clone()
-                .spawn_with(|c| c.arg("remote").arg("add").arg("origin").arg(url), None)
-                .await?;
-            git.clone()
-                .fetch("origin", pb)
-                .and_then(|_| async {
-                    if let Some(reference) = fetch_ref {
-                        git.clone().fetch_ref("origin", reference, None).await
-                    } else {
-                        Ok(())
-                    }
-                })
-                .await
-                .map_err(move |cause| {
-                    Error::from(SessionErrors::GitDatabaseAccess(
-                        "initialize",
-                        url.contains("git@"),
-                        cause.into(),
-                    ))
-                })
-                .map(move |_| git)
+        let action = if !db_dir.join("config").exists() {
+            DbAction::Init
         } else {
-            // Update if the manifest has been modified since the last fetch.
             let db_mtime = try_modification_time(db_dir.join("FETCH_HEAD"));
             let skip_fetch = match force_fetch {
                 Some(true) => false,
@@ -774,41 +833,12 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
                 None => self.sess.manifest_mtime < db_mtime,
             };
             if skip_fetch || self.sess.local_only {
-                log::info!(
-                    "skipping fetch of {:?} (skip_fetch={}, local_only={})",
-                    db_dir,
-                    skip_fetch,
-                    self.sess.local_only
-                );
-                return Ok(git);
+                DbAction::Ready
+            } else {
+                DbAction::Fetch
             }
-            log::info!("fetching updates for {} from {}", name, url);
-            self.sess.stats.num_database_fetch.increment();
-            // The progress bar object for fetching.
-            let pb = Some(ProgressHandler::new(
-                self.sess.multiprogress.clone(),
-                GitProgressOps::Fetch,
-                name,
-            ));
-            git.clone()
-                .fetch("origin", pb)
-                .and_then(|_| async {
-                    if let Some(reference) = fetch_ref {
-                        git.clone().fetch_ref("origin", reference, None).await
-                    } else {
-                        Ok(())
-                    }
-                })
-                .await
-                .map_err(move |cause| {
-                    Error::from(SessionErrors::GitDatabaseAccess(
-                        "update",
-                        url.contains("git@"),
-                        cause.into(),
-                    ))
-                })
-                .map(move |_| git)
-        }
+        };
+        Ok((git, action))
     }
 
     /// Determine the list of versions available for a git dependency.
@@ -976,10 +1006,10 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
         url: &str,
         revision: &str,
     ) -> Result<()> {
+        // Make sure the database exists, then take the exclusive lock for the
+        // by-hash fetch, which is the only mutation here.
+        let git = self.git_database(name, url, Some(false), None).await?;
         let _wlock = FsLock::acquire_exclusive(self.sess.dep_lock_path(name, url)).await?;
-        let git = self
-            .git_database_locked(name, url, Some(false), None)
-            .await?;
         let pb = Some(ProgressHandler::new(
             self.sess.multiprogress.clone(),
             GitProgressOps::Fetch,
@@ -1051,12 +1081,15 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
         force: bool,
         update_list: &[String],
     ) -> Result<&'ctx Path> {
-        // A checkout reads from the shared bare database (via `git clone
-        // --shared`) but never writes to it, so a shared lock is enough and
-        // lets concurrent invocations check out in parallel against a warm,
-        // pre-populated database. The only writer path is the fallback fetch
-        // below (when the locked revision is missing from the database), which
-        // briefly drops this lock and takes an exclusive one of its own.
+        // Resolve (and, if necessary, initialize) the bare database before
+        // taking the lock we hold across the checkout. A checkout reads from the
+        // database (via `git clone --shared`) but never writes to it, so a
+        // shared lock is enough and lets concurrent invocations check out in
+        // parallel against a warm, pre-populated database. The only writer path
+        // is the fallback fetch below (when the locked revision is missing from
+        // the database), which briefly drops this lock and takes an exclusive
+        // one of its own.
+        let db = self.git_database(name, url, Some(false), None).await?;
         let mut db_lock = Some(FsLock::acquire_shared(self.sess.dep_lock_path(name, url)).await?);
 
         #[derive(Eq, PartialEq)]
@@ -1074,15 +1107,9 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
                     log::debug!("currently `{}` (want `{}`)", current, revision);
                     if current == revision {
                         CheckoutState::Clean
-                    } else if let Ok(db) =
-                        self.git_database_locked(name, url, Some(false), None).await
-                    {
-                        if let Ok(remote) = local_git.clone().remote_url("origin").await {
-                            if remote == db.path.to_str().unwrap() {
-                                CheckoutState::ToCheckout
-                            } else {
-                                CheckoutState::ToClone
-                            }
+                    } else if let Ok(remote) = local_git.clone().remote_url("origin").await {
+                        if remote == db.path.to_str().unwrap() {
+                            CheckoutState::ToCheckout
                         } else {
                             CheckoutState::ToClone
                         }
@@ -1140,11 +1167,9 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
             // check under the shared lock. If the revision is missing (e.g. the
             // cached database predates the locked commit), it must be fetched,
             // which mutates the database: drop the shared lock, fetch via
-            // `git_database` (which locks exclusively), then re-take the shared
-            // lock and continue.
-            let mut git = self
-                .git_database_locked(name, url, Some(false), None)
-                .await?;
+            // `git_database` (which escalates to an exclusive lock internally),
+            // then re-take the shared lock and continue.
+            let mut git = db.clone();
             let revision_check = revision.to_string();
             let have_commit = git
                 .clone()

--- a/src/sess.rs
+++ b/src/sess.rs
@@ -560,29 +560,22 @@ impl<'ctx> Session<'ctx> {
         db_name
     }
 
-    /// Path of the cross-process advisory lock file for a git dependency.
-    ///
-    /// This single file coordinates access to the bare database under
-    /// `git/db/` for this dependency. Writers (database initialization and
-    /// fetches) take it exclusively; readers (version resolution and checkouts)
-    /// take it shared, so concurrent invocations against a populated database
-    /// do not serialize.
-    pub fn dep_lock_path(&self, name: &str, url: &str) -> PathBuf {
+    /// Path of the cross-process advisory lock file guarding a dependency's
+    /// bare git database. The lock lives as a sibling of the database directory
+    /// itself, i.e. `.bender/git/db/<name>-<hash>.lock` next to the bare repo at
+    /// `.bender/git/db/<name>-<hash>/`.
+    pub fn db_lock_path(&self, name: &str, url: &str) -> PathBuf {
         let key = self.git_db_name(name, url);
         self.db_parent()
             .join("git")
-            .join("locks")
+            .join("db")
             .join(format!("{}.lock", key))
     }
 
     /// Path of the cross-process advisory lock file for a working-tree
     /// checkout.
     ///
-    /// Held exclusively across `checkout_git` so that two bender invocations
-    /// that resolve to the same checkout directory -- e.g. two runs against the
-    /// same project root -- cannot interleave their `remove_dir_all` / `git
-    /// clone` / `git checkout` operations and corrupt the working tree. The
-    /// lock file lives as a sibling of the checkout directory so it travels
+    /// The lock file lives as a sibling of the checkout directory so it travels
     /// with the project, independent of where the bare database is stored.
     pub fn checkout_lock_path(&self, checkout_path: &Path) -> PathBuf {
         let mut p = checkout_path.as_os_str().to_owned();
@@ -694,16 +687,9 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
     /// Access the git database for a dependency, creating or updating it as
     /// needed.
     ///
-    /// Locking is fine-grained. The common case -- the database already exists
-    /// and is current -- only takes a shared lock, so concurrent read-only
-    /// callers run in parallel instead of serializing. Only when an
-    /// initialization or fetch is actually required is the lock escalated to
-    /// exclusive, and the database state is re-checked under it in case another
-    /// process performed the work while we were briefly unlocked. The lock is
-    /// released before returning; the returned handle is used for read-only
-    /// access. Callers that themselves mutate (e.g. a checkout holding a
-    /// long-lived shared lock and fetching on a fallback path) manage their own
-    /// locking around this call.
+    /// The common case (database present and current) takes only a shared lock,
+    /// escalating to exclusive just for an init or fetch and re-checking state
+    /// under it. The lock is released before returning the read-only handle.
     async fn git_database(
         &'io self,
         name: &str,
@@ -716,22 +702,22 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
         //       Then use that table to return the future if it already exists.
         //       This ensures that the gitdb is setup only once, and makes the
         //       whole process faster for later calls.
-        let lock_path = self.sess.dep_lock_path(name, url);
+        let db_lock = FsLock::new(self.sess.db_lock_path(name, url));
 
         // Fast path: under a shared lock, check whether the database is already
         // present and up to date. If so, nothing has to be mutated and we can
         // return right away, letting concurrent readers run in parallel.
-        let shared = FsLock::acquire_shared(lock_path.clone()).await?;
+        let shared_guard = db_lock.acquire_shared().await?;
         let (git, action) = self.git_database_action(name, url, force_fetch)?;
         if let DbAction::Ready = action {
             return Ok(git);
         }
-        drop(shared);
+        drop(shared_guard);
 
         // A mutation (initialization or fetch) is required. Take the exclusive
         // lock and re-evaluate: another process may have completed the work
         // while we were briefly unlocked, in which case there is nothing to do.
-        let _exclusive = FsLock::acquire_exclusive(lock_path).await?;
+        let _exclusive_guard = db_lock.acquire_exclusive().await?;
         let (git, action) = self.git_database_action(name, url, force_fetch)?;
         match action {
             DbAction::Ready => Ok(git),
@@ -1018,10 +1004,7 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
     /// This recovers a commit that was force-pushed off every branch and tag
     /// upstream (so it is not advertised and a normal fetch does not retrieve
     /// it) but remains reachable on the server and thus fetchable by hash. The
-    /// fetch mutates the database, so the exclusive lock is taken for it. The
-    /// fetch itself is best-effort -- not every server allows fetching an
-    /// unadvertised commit by hash -- so its result is ignored; the caller
-    /// verifies whether the commit became available.
+    /// fetch mutates the database, so the exclusive lock is taken for it.
     async fn fetch_revision_by_hash(
         &'io self,
         name: &str,
@@ -1031,7 +1014,9 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
         // Make sure the database exists, then take the exclusive lock for the
         // by-hash fetch, which is the only mutation here.
         let git = self.git_database(name, url, Some(false), None).await?;
-        let _wlock = FsLock::acquire_exclusive(self.sess.dep_lock_path(name, url)).await?;
+        let _exclusive_guard = FsLock::new(self.sess.db_lock_path(name, url))
+            .acquire_exclusive()
+            .await?;
         let pb = Some(ProgressHandler::new(
             self.sess.multiprogress.clone(),
             GitProgressOps::Fetch,
@@ -1103,27 +1088,21 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
         force: bool,
         update_list: &[String],
     ) -> Result<&'ctx Path> {
-        // Serialize concurrent bender invocations that resolve to the same
-        // checkout directory -- typically two runs against the same project
-        // root. Without this, the shared db lock taken below does not protect
-        // us: shared lockers don't block each other, so two simultaneous
-        // `checkout_git` calls could interleave `remove_dir_all`, `git clone`,
-        // and `git checkout` on the same working tree and corrupt it. The lock
-        // is per checkout path, so unrelated deps (and the same dep across
-        // different projects, which resolve to distinct paths) still run in
-        // parallel.
-        let _checkout_lock = FsLock::acquire_exclusive(self.sess.checkout_lock_path(path)).await?;
+        // Serialize invocations that resolve to the same checkout path, so they
+        // can't interleave `remove_dir_all`/`git clone`/`git checkout` on the
+        // same working tree. Per-path, so unrelated checkouts still run in
+        // parallel; the shared db lock below wouldn't serialize these.
+        let _checkout_guard = FsLock::new(self.sess.checkout_lock_path(path))
+            .acquire_exclusive()
+            .await?;
 
-        // Resolve (and, if necessary, initialize) the bare database before
-        // taking the lock we hold across the checkout. A checkout reads from the
-        // database (via `git clone --shared`) but never writes to it, so a
-        // shared lock is enough and lets concurrent invocations check out in
-        // parallel against a warm, pre-populated database. The only writer path
-        // is the fallback fetch below (when the locked revision is missing from
-        // the database), which briefly drops this lock and takes an exclusive
-        // one of its own.
+        // A checkout only reads the database (via `git clone --shared`), so a
+        // shared lock suffices and lets concurrent checkouts proceed in
+        // parallel. The fallback fetch below (locked revision missing) is the
+        // only writer; it briefly drops this lock for an exclusive one.
         let db = self.git_database(name, url, Some(false), None).await?;
-        let mut db_lock = Some(FsLock::acquire_shared(self.sess.dep_lock_path(name, url)).await?);
+        let db_lock = FsLock::new(self.sess.db_lock_path(name, url));
+        let mut db_guard = Some(db_lock.acquire_shared().await?);
 
         #[derive(Eq, PartialEq)]
         enum CheckoutState {
@@ -1195,13 +1174,11 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
 
         // Perform the checkout if necessary.
         if clear != CheckoutState::Clean {
-            // Ensure the requested revision is present in the database. The
-            // database is normally already populated, so this is a read-only
-            // check under the shared lock. If the revision is missing (e.g. the
-            // cached database predates the locked commit), it must be fetched,
-            // which mutates the database: drop the shared lock, fetch via
-            // `git_database` (which escalates to an exclusive lock internally),
-            // then re-take the shared lock and continue.
+            // Ensure the revision is present -- normally a read-only check
+            // under the shared lock. If it's missing (cached database predates
+            // the locked commit), drop the shared lock, fetch via
+            // `git_database` (which takes its own exclusive lock), then re-take
+            // the shared lock.
             let mut git = db.clone();
             let revision_check = revision.to_string();
             let have_commit = git
@@ -1218,22 +1195,17 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
                 .is_ok();
             if !have_commit {
                 log::debug!("revision {} not in database, fetching.", revision);
-                drop(db_lock.take());
+                drop(db_guard.take());
                 git = self.git_database(name, url, Some(true), None).await?;
-                db_lock = Some(FsLock::acquire_shared(self.sess.dep_lock_path(name, url)).await?);
+                db_guard = Some(db_lock.acquire_shared().await?);
             }
-            // Check if the revision is reachable from any upstream branch or
-            // tag. If not, warn that the commit may have been removed by a
-            // force-push. Synthetic `bender-tmp-*` tags are excluded: they are
-            // created by `dependency_versions` (and may persist in databases
-            // populated by older bender versions from the old checkout flow),
-            // and they do not represent upstream tracking.
+            // Warn if the revision isn't reachable from any upstream branch or
+            // tag (e.g. removed by a force-push). Synthetic `bender-tmp-*` tags
+            // from `dependency_versions` are excluded: they don't represent
+            // upstream tracking but may linger in older databases.
             //
-            // TODO: drop this filter once `bender-tmp-*` tags are either no
-            // longer created (e.g. by replacing the `rev-list --all` use in
-            // `dependency_versions` with a hash-based reachability check) or
-            // swept after use; the filter is here to remain correct on
-            // databases that still contain such tags.
+            // TODO: drop this filter once `bender-tmp-*` tags are no longer
+            // created or are swept after use.
             let revision_owned = revision.to_string();
             if let Ok(ref_output) = git
                 .clone()
@@ -1257,13 +1229,7 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
                 // Clone the working tree from the database, borrowing its
                 // objects via `--shared` (alternates) so nothing is copied and
                 // the database is left untouched. `--no-checkout` keeps the
-                // worktree empty so the exact revision can be checked out next;
-                // no temporary tag in the database is needed. This step
-                // transfers no objects and writes no working-tree files, so it
-                // runs without its own progress handler: the user-facing
-                // progress and finish line come from the checkout below, and a
-                // separate handler here would report the dependency as "Checked
-                // out" twice.
+                // worktree empty so the exact revision can be checked out next.
                 git.clone()
                     .spawn_with(
                         move |c| {
@@ -1320,9 +1286,9 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
                     "checkout of {} failed, fetching the commit by hash and retrying.",
                     revision
                 );
-                drop(db_lock.take());
+                drop(db_guard.take());
                 self.fetch_revision_by_hash(name, url, revision).await?;
-                db_lock = Some(FsLock::acquire_shared(self.sess.dep_lock_path(name, url)).await?);
+                db_guard = Some(db_lock.acquire_shared().await?);
                 self.checkout_revision(&local_git, revision, name)
                     .await
                     .map_err(|cause| {
@@ -1388,7 +1354,7 @@ impl<'io, 'sess: 'io, 'ctx: 'sess> SessionIo<'sess, 'ctx> {
             }
         }
         // Hold the database lock until the checkout is fully materialized.
-        drop(db_lock);
+        drop(db_guard);
         Ok(path)
     }
 


### PR DESCRIPTION
In #307 we introduced database locks and separaring database from checkout in order to share the database as a cache cross projects. This is also relevant in the context of CI, since the git databases are only fetched once and can then be reused. However, the _exclusive_ locks on the databases essentially prevent any kind of parallelization and every invocation of bender becomes serialized across CI jobs.

This PR aims to relax the locks to use exclusive locks only when writing to the database, and use shared locks when reading from it.

The flow of fetching and checking out a git repository was slightly adapted to reduce the amount of write operations on a shared database:
* `git init` and `git fetch [<rev>]` are write operations and still acquire an exclusive lock
* The creation of a temporary tag `tmp-<hash>` in the database and the later checkout with `git clone --branch tmp-<hash>` has been replaced with `git clone --shared --no-checkout && git checkout <rev>`
* The database is configured to disable `git gc` since revisions might not be tracked anymore by refs i.e. the previous `tmp-<hash>` tags. This is maybe overly catious.

Furthermore, file locking is done more fine grained. Instead of locking the whole `git_database` call exclusively, only the part that requires writes (`git init` and `git fetch`) acquire an exclusive lock (if database is not ready yet).