### PR TITLE
script: keep untyped files in flist output

### DIFF
--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -900,8 +900,12 @@ fn emit_template(
         }
         separate_files_in_group(
             src,
+            // Categorize by file type. The extra `Some(..)` wrapper means untyped files
+            // (`SourceType` = None, e.g. a `.c`/`.tcl`/`.txt` listed in the sources) form their
+            // own group rather than being dropped: only real `Group` entries — which don't
+            // survive `flatten()` — categorize to `None` and get skipped.
             |f| match f {
-                SourceFile::File(_, fmt) => *fmt,
+                SourceFile::File(_, fmt) => Some(*fmt),
                 _ => None,
             },
             |src, ty, files| {
@@ -957,7 +961,7 @@ fn emit_template(
                             SourceFile::Group(_) => unreachable!(),
                         })
                         .collect(),
-                    file_type: Some(ty),
+                    file_type: ty,
                 });
             },
         );

--- a/src/script_fmt/formality_tcl.tera
+++ b/src/script_fmt/formality_tcl.tera
@@ -2,7 +2,7 @@
 set ROOT "{{ root }}"
 set search_path_initial $search_path
 {# Separate compilation: one block per source group -#}
-{% if compilation_mode == 'separate' %}{% for group in srcs %}{% if group.file_type != '' %}{% if source_annotations %}
+{% if compilation_mode == 'separate' %}{% for group in srcs %}{% if group.file_type == 'verilog' or group.file_type == 'vhdl' %}{% if source_annotations %}
 # {{ group.metadata }}{% endif %}
 set search_path $search_path_initial
 {% for incdir in group.incdirs %}lappend search_path "$ROOT{{ incdir | replace(from=root, to='') }}"
@@ -17,7 +17,11 @@ set search_path $search_path_initial
     {% endif %}{% endif %}{{ '    ' }}"{{ file.file | replace(from=root, to='$ROOT') }}" \
     {% endfor %}]
 {% if abort_on_error %}}]} {return 1}{% endif %}
-{% endif %}{% endfor %}
+{% else %}{% if source_annotations %}
+# {{ group.metadata }}{% endif %}
+# Skipping {{ group.files | length }} file(s) of unknown type (prefix with sv:/v:/vhd: to set one):
+{% for file in group.files %}#   {{ file.file | replace(from=root, to='$ROOT') }}
+{% endfor %}{% endif %}{% endfor %}
 {# Common compilation: all files in one block -#}
 {% else -%}
 {# Verilog sources -#}

--- a/src/script_fmt/genus_tcl.tera
+++ b/src/script_fmt/genus_tcl.tera
@@ -6,7 +6,7 @@ if [ info exists search_path ] {
 }
 set ROOT "{{ root }}"
 {# Separate compilation: one block per source group -#}
-{% if compilation_mode == 'separate' %}{% for group in srcs %}{% if group.file_type != '' %}{% if source_annotations %}
+{% if compilation_mode == 'separate' %}{% for group in srcs %}{% if group.file_type == 'verilog' or group.file_type == 'vhdl' %}{% if source_annotations %}
 # {{ group.metadata }}{% endif %}
 set search_path $search_path_initial
 {% for incdir in group.incdirs %}lappend search_path "{{ incdir | replace(from=root, to='$ROOT') }}"
@@ -22,7 +22,11 @@ set search_path $search_path_initial
     {% for file in group.files %}{% if source_annotations %}{% if file.comment %}{{ '    ' }}# {{ file.comment }}
     {% endif %}{% endif %}{{ '    ' }}"{{ file.file | replace(from=root, to='$ROOT') }}" \
     {% endfor %}]
-{% endif %}{% endfor %}
+{% else %}{% if source_annotations %}
+# {{ group.metadata }}{% endif %}
+# Skipping {{ group.files | length }} file(s) of unknown type (prefix with sv:/v:/vhd: to set one):
+{% for file in group.files %}#   {{ file.file | replace(from=root, to='$ROOT') }}
+{% endfor %}{% endif %}{% endfor %}
 {# Common compilation: all files in one block -#}
 {% else -%}
 {# Verilog sources -#}

--- a/src/script_fmt/precision_tcl.tera
+++ b/src/script_fmt/precision_tcl.tera
@@ -11,7 +11,7 @@ setup_design -defines { \
 
 {% else %} \
     {% endif %}{% endfor %}{# Separate compilation: one block per source group -#}
-{% if compilation_mode == 'separate' %}{% for group in srcs %}{% if group.file_type != '' %}{% if source_annotations %}# {{ group.metadata }}
+{% if compilation_mode == 'separate' %}{% for group in srcs %}{% if group.file_type == 'verilog' or group.file_type == 'vhdl' %}{% if source_annotations %}# {{ group.metadata }}
 {% endif %}{% if abort_on_error %}if {[catch { {% endif %}add_input_file \
     {% if group.file_type == 'verilog' %}-format SystemVerilog2012 \
     {% for incdir in group.incdirs %}{% if loop.first %}-search_path { \
@@ -26,6 +26,10 @@ setup_design -defines { \
         {% endif %}{% endfor %}} \
 {% if abort_on_error %}}]} {return 1}
 {% endif %}
+{% else %}{% if source_annotations %}# {{ group.metadata }}
+{% endif %}# Skipping {{ group.files | length }} file(s) of unknown type (prefix with sv:/v:/vhd: to set one):
+{% for file in group.files %}#   {{ file.file }}
+{% endfor %}
 {% endif %}{% endfor %}
 {# Common compilation: all files in one block -#}
 {% else -%}

--- a/src/script_fmt/riviera_tcl.tera
+++ b/src/script_fmt/riviera_tcl.tera
@@ -2,7 +2,7 @@
 set ROOT "{{ root }}"
 vlib work
 {# Separate compilation: one block per source group -#}
-{% if compilation_mode == 'separate' %}{% for group in srcs %}{% if group.file_type != '' %}{% if source_annotations %}# {{ group.metadata }}
+{% if compilation_mode == 'separate' %}{% for group in srcs %}{% if group.file_type == 'verilog' or group.file_type == 'vhdl' %}{% if source_annotations %}# {{ group.metadata }}
 {% endif %}{% if abort_on_error %}if {[catch { {% endif %}{% if group.file_type == 'verilog' %}vlog -sv \
     {% for tmp_arg in vlog_args %}{{ tmp_arg }} \
     {% endfor %}{% for define in group.defines %}"+define+{{ define.0 }}{% if define.1 %}={{ define.1 }}{% endif %}" \
@@ -14,6 +14,10 @@ vlib work
     {% else %}\
 {% endif %}{% endfor %}{% if abort_on_error %}}]} {return 1}{% endif %}
 
+{% else %}{% if source_annotations %}# {{ group.metadata }}
+{% endif %}# Skipping {{ group.files | length }} file(s) of unknown type (prefix with sv:/v:/vhd: to set one):
+{% for file in group.files %}#   {{ file.file | replace(from=root, to='$ROOT') }}
+{% endfor %}
 {% endif %}{% endfor -%}
 {# Common compilation: all files in one block -#}
 {%- else -%}

--- a/src/script_fmt/synopsys_tcl.tera
+++ b/src/script_fmt/synopsys_tcl.tera
@@ -3,7 +3,7 @@ set ROOT "{{ root }}"
 set search_path_initial $search_path
 {# Separate compilation: one block per source group -#}
 {% if compilation_mode == 'separate' -%}
-{%- for group in srcs %}{% if group.file_type != '' %}{% if source_annotations %}
+{%- for group in srcs %}{% if group.file_type == 'verilog' or group.file_type == 'vhdl' %}{% if source_annotations %}
 # {{ group.metadata }}{% endif %}
 set search_path $search_path_initial
 {% for incdir in group.incdirs -%}
@@ -29,7 +29,11 @@ analyze -format {% if group.file_type == 'verilog' %}sv{% elif group.file_type =
 {% endif %}{% endif %}{{ '    ' }}"{{ file.file | replace(from=root, to='$ROOT') }}" \
     {% endfor %}]
 {% if abort_on_error %}]} {return 1}{% endif %}
-{% endif %}{% endfor %}
+{% else %}{% if source_annotations %}
+# {{ group.metadata }}{% endif %}
+# Skipping {{ group.files | length }} file(s) of unknown type (prefix with sv:/v:/vhd: to set one):
+{% for file in group.files %}#   {{ file.file | replace(from=root, to='$ROOT') }}
+{% endfor %}{% endif %}{% endfor %}
 {# Common compilation: all files in one block -#}
 {% else -%}
 {# Verilog sources -#}

--- a/src/script_fmt/vcs_sh.tera
+++ b/src/script_fmt/vcs_sh.tera
@@ -5,7 +5,7 @@ set -e
 {% endif %}
 ROOT="{{ root }}"
 {# Separate compilation: one block per source group -#}
-{% if compilation_mode == 'separate' %}{% for group in srcs %}{% if group.file_type != '' %}{% if source_annotations %}
+{% if compilation_mode == 'separate' %}{% for group in srcs %}{% if group.file_type == 'verilog' or group.file_type == 'vhdl' %}{% if source_annotations %}
 # {{ group.metadata }}{% endif %}
 {% if group.file_type == 'verilog' %}{{ vlogan_bin }} -sverilog \
     -full64 \
@@ -16,7 +16,11 @@ ROOT="{{ root }}"
     {% for tmp_arg in vhdlan_args %}{{ tmp_arg }} \
     {% endfor %}{% endif %}{% for file in group.files %}"{{ file.file | replace(from=root, to='$ROOT') }}" {% if not loop.last %}\
     {% endif %}{% endfor %}
-{% endif %}{% endfor %}
+{% else %}{% if source_annotations %}
+# {{ group.metadata }}{% endif %}
+# Skipping {{ group.files | length }} file(s) of unknown type (prefix with sv:/v:/vhd: to set one):
+{% for file in group.files %}#   {{ file.file | replace(from=root, to='$ROOT') }}
+{% endfor %}{% endif %}{% endfor %}
 {# Common compilation: all files in one block -#}
 {% else -%}
 {# Verilog sources -#}

--- a/src/script_fmt/vsim_tcl.tera
+++ b/src/script_fmt/vsim_tcl.tera
@@ -2,7 +2,7 @@
 set ROOT "{{ root }}"
 {# Separate compilation: one block per source group -#}
 {% if compilation_mode == 'separate' -%}
-{%- for group in srcs %}{% if group.file_type != '' %}
+{%- for group in srcs %}{% if group.file_type == 'verilog' or group.file_type == 'vhdl' %}
 {% if source_annotations %}# {{ group.metadata }}
 {% endif -%}
 {%- if abort_on_error %}if {[catch { {% endif -%}
@@ -24,6 +24,12 @@ set ROOT "{{ root }}"
 {%- endfor -%}
 {%- if abort_on_error %}\
 }]} {return 1}{% endif %}
+{% else %}
+{% if source_annotations %}# {{ group.metadata }}
+{% endif -%}
+# Skipping {{ group.files | length }} file(s) of unknown type (prefix with sv:/v:/vhd: to set one):
+{% for file in group.files %}#   {{ file.file | replace(from=root, to='$ROOT') }}
+{% endfor -%}
 {% endif %}{% endfor -%}
 {# Common compilation: all files in one block -#}
 {%- else -%}

--- a/tests/pickle/Bender.yml
+++ b/tests/pickle/Bender.yml
@@ -35,3 +35,8 @@ sources:
   - target: broken
     files:
       - src/broken.sv
+
+  - target: untyped
+    files:
+      - src/misc_rtl.sv
+      - src/misc_notes.txt

--- a/tests/pickle/src/misc_notes.txt
+++ b/tests/pickle/src/misc_notes.txt
@@ -1,0 +1,2 @@
+This is not an HDL source file. Bender should still list it in flist output
+and comment it out (rather than try to compile it) in tool-specific scripts.

--- a/tests/pickle/src/misc_rtl.sv
+++ b/tests/pickle/src/misc_rtl.sv
@@ -1,0 +1,2 @@
+module misc_rtl;
+endmodule

--- a/tests/script.rs
+++ b/tests/script.rs
@@ -51,7 +51,7 @@ mod tests {
     /// all-backslash because the Bender.yml entry has no embedded separator — so splitting on
     /// `/` alone misses the latter.
     fn basename(path: &str) -> &str {
-        match path.rfind(|c: char| c == '/' || c == '\\') {
+        match path.rfind(['/', '\\']) {
             Some(i) => &path[i + 1..],
             None => path,
         }
@@ -379,5 +379,60 @@ mod tests {
             !trimmed.contains("dup_a.sv"),
             "dup_a.sv (overwritten) should be absent: {trimmed:?}"
         );
+    }
+
+    /// Regression test: files whose extension isn't a recognized HDL type (e.g. `.txt`) must
+    /// still appear in `flist`/`flist-plus` output. They used to be silently dropped once the
+    /// file list switched to iterating per-type source groups.
+    #[test]
+    fn script_untyped_files_kept_in_flist() {
+        for fmt in ["flist", "flist-plus"] {
+            let out = run_script(&["--target", "untyped", fmt]);
+            let files = source_basenames(&out);
+            assert!(
+                files.contains("misc_rtl.sv"),
+                "typed file missing from {fmt}: {files:?}"
+            );
+            assert!(
+                files.contains("misc_notes.txt"),
+                "untyped file must be kept in {fmt}: {files:?}"
+            );
+        }
+    }
+
+    /// Tool scripts that branch on file type must not emit a broken compile command for untyped
+    /// files: they comment them out instead. Verify the untyped file appears only on comment
+    /// lines and that a skip notice is present.
+    #[test]
+    fn script_untyped_files_commented_in_tool_scripts() {
+        for fmt in [
+            "vsim",
+            "vcs",
+            "synopsys",
+            "formality",
+            "riviera",
+            "genus",
+            "precision",
+        ] {
+            let out = run_script(&["--target", "untyped", fmt]);
+            let mentions: Vec<&str> = out
+                .lines()
+                .filter(|l| l.contains("misc_notes.txt"))
+                .collect();
+            assert!(
+                !mentions.is_empty(),
+                "untyped file absent from {fmt} output:\n{out}"
+            );
+            for line in &mentions {
+                assert!(
+                    line.trim_start().starts_with('#'),
+                    "untyped file must only appear in comments for {fmt}, got line {line:?}\nfull:\n{out}"
+                );
+            }
+            assert!(
+                out.contains("Skipping") && out.contains("unknown type"),
+                "expected an unknown-type skip notice in {fmt} output:\n{out}"
+            );
+        }
     }
 }


### PR DESCRIPTION
Regression from v0.30.0 (d0c1e13): switching the flist/flist-plus templates from `all_files` to the per-type split source groups silently dropped files whose extension isn't a recognized HDL type (.c, .tcl, .txt, ...), because untyped files were never emitted into those groups.

Emit untyped files as their own groups (file_type = None) so they reappear in flist/flist-plus. Tool-script formats that branch on file type (vsim, vcs, synopsys, formality, riviera, genus, precision) previously fell through their `file_type != ''` guard and emitted broken compile commands for such files; they now comment them out instead. Type-agnostic (vivado) and Verilog-only (verilator) formats are unaffected.

Add a regression fixture with a non-HDL file plus tests covering flist inclusion and tool-script commenting.