### PR TITLE
book: Add `tb` target convention

### DIFF
--- a/book/src/targets.md
+++ b/book/src/targets.md
@@ -131,7 +131,8 @@ The `bender script` command activates the following targets based on the chosen 
 
 Bender does not enforce these, but the following user-defined targets are widely used across PULP projects and are a good default for new packages:
 
-- **`test`** — testbench code and verification IP, kept out of synthesis flows.
+- **`test`** — reusable verification IP, kept out of synthesis flows.
+- **`tb`** — non-reusable testbench and testharness code, kept out of synthesis flows.
 - **`rtl`** — synthesizable RTL code.
 - **`gate`** — gate-level netlists, used in post-synthesis simulation and timing flows.
 


### PR DESCRIPTION
This PR suggests to split the conventional `test` target into separate `test` and `tb` targets. `test` includes reusable test sources that might be used by dependent repos. `tb` includes repo-specific testbenches that are not expected to be reused by other repos.

See https://github.com/pulp-platform/common_cells/pull/340 for a specific use case.