### PR TITLE
clone: rename -p/--path flag to --working-dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Unreleased
 ### Changed
-- `bender clone`: rename `-p`/`--path` flag to `--working-dir` to match `bender snapshot`'s flag for the same concept.
+- `bender clone`: primary flag for the checkout directory is now `--working-dir`, matching `bender snapshot`'s flag for the same concept; `-p`/`--path` are kept as hidden aliases for backwards compatibility.
 
 ## 0.32.1 - 2026-07-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- `bender clone`: rename `-p`/`--path` flag to `--working-dir` to match `bender snapshot`'s flag for the same concept.
 
 ## 0.32.1 - 2026-07-07
 ### Added

--- a/book/src/commands.md
+++ b/book/src/commands.md
@@ -132,7 +132,7 @@ Calling update with the `--fetch/-f` flag will force all git dependencies to be 
 
 ## `clone` --- Clone dependency to make modifications
 
-The `bender clone <PKG>` command checks out the package `PKG` into a directory (default `working_dir`, can be overridden with `-p / --path <DIR>`).
+The `bender clone <PKG>` command checks out the package `PKG` into a directory (default `working_dir`, can be overridden with `--working-dir <DIR>`).
 To ensure the package is correctly linked in bender, the [`Bender.local`](./local.md) file is modified to include a `path` dependency override, linking to the corresponding package.
 
 This can be used for development of dependent packages within the parent repository, allowing to test uncommitted and committed changes, without the worry that bender would update the dependency.

--- a/book/src/workflow/package_dev.md
+++ b/book/src/workflow/package_dev.md
@@ -11,7 +11,7 @@ Use the `clone` command to move a dependency from Bender's internal cache into a
 bender clone <PKG_NAME>
 ```
 
-By default, the package is checked out into a `working_dir` folder (you can change this with `-p/--path`). Bender automatically:
+By default, the package is checked out into a `working_dir` folder (you can change this with `--working-dir`). Bender automatically:
 1.  Performs a `git clone` of the dependency into that folder.
 2.  Adds a `path` override to your [`Bender.local`](../local.md) file.
 

--- a/src/cmd/clone.rs
+++ b/src/cmd/clone.rs
@@ -28,7 +28,7 @@ pub struct CloneArgs {
     pub name: String,
 
     /// Relative directory to clone PKG into
-    #[arg(short = 'p', long, alias = "path", default_value = "working_dir")]
+    #[arg(long, short_alias = 'p', alias = "path", default_value = "working_dir")]
     pub working_dir: String,
 }
 

--- a/src/cmd/clone.rs
+++ b/src/cmd/clone.rs
@@ -28,8 +28,8 @@ pub struct CloneArgs {
     pub name: String,
 
     /// Relative directory to clone PKG into
-    #[arg(short, long, default_value = "working_dir")]
-    pub path: String,
+    #[arg(long, default_value = "working_dir")]
+    pub working_dir: String,
 }
 
 /// Execute the `clone` subcommand.
@@ -37,7 +37,7 @@ pub fn run(sess: &Session, path: &Path, args: &CloneArgs) -> Result<()> {
     let dep = &args.name.to_lowercase();
     let depref = sess.dependency_with_name(dep)?;
 
-    let path_mod = &args.path; // TODO make this option for config in the Bender.yml file?
+    let path_mod = &args.working_dir; // TODO make this option for config in the Bender.yml file?
     // Check current config for matches
     if sess.config.overrides.contains_key(dep) {
         match &sess.config.overrides[dep] {

--- a/src/cmd/clone.rs
+++ b/src/cmd/clone.rs
@@ -28,7 +28,7 @@ pub struct CloneArgs {
     pub name: String,
 
     /// Relative directory to clone PKG into
-    #[arg(long, default_value = "working_dir")]
+    #[arg(short = 'p', long, alias = "path", default_value = "working_dir")]
     pub working_dir: String,
 }
 


### PR DESCRIPTION
## Summary
- `bender clone` used `-p`/`--path` and `bender snapshot` used `--working-dir` for the same working-directory concept (same default value `working_dir`, same semantics). `--working-dir` is now the primary, documented flag for `clone` too, matching `snapshot`.
- `-p`/`--path` are kept as fully-working hidden aliases on `clone` for backwards compatibility — neither appears in `--help`, but both still parse.
- Updated the `docs/book` references and added a CHANGELOG entry.

Not a breaking change: existing `-p`/`--path` usage keeps working.

## Test plan
- [x] `cargo check --no-default-features` passes
- [x] `bender clone --help` shows only `--working-dir <WORKING_DIR>` (no `-p`/`--path`)
- [x] `bender clone -p <dir> <pkg>` and `bender clone --path <dir> <pkg>` still parse correctly
- [x] `bender snapshot --help` shows `--working-dir <WORKING_DIR>` (unchanged)
