### PR TITLE
fix(rewriter): preserve scoped nested renames

### DIFF
--- a/crates/bender-slang/cpp/rewriter.cpp
+++ b/crates/bender-slang/cpp/rewriter.cpp
@@ -198,6 +198,8 @@ class ReferenceRewriter : public SyntaxRewriter<ReferenceRewriter> {
         ScopedNameSyntax* newNode = deepClone(node, alloc);
         newNode->left = newLeft;
 
+        rewrite_scoped_names_inplace(*newNode->right);
+
         replace(node, *newNode);
         refRenamed++;
     }

--- a/tests/pickle.rs
+++ b/tests/pickle.rs
@@ -147,6 +147,16 @@ mod tests {
     }
 
     #[test]
+    fn pickle_rename_renames_scoped_packed_dimensions() {
+        let renamed = run_pickle(&["--prefix", "p_", "--suffix", "_s", "--expand-macros"]);
+
+        // A packed dimension is parsed as part of the scoped type name it follows,
+        // so a scoped name inside it must be renamed along with the type itself.
+        assert!(renamed.contains("p_common_pkg_s::state_t [p_common_pkg_s::NumStates-1:0]"));
+        assert!(!renamed.contains("common_pkg::NumStates-1:0"));
+    }
+
+    #[test]
     fn pickle_rename_renames_scoped_instantiation_params() {
         let renamed = run_pickle(&[
             "--target",

--- a/tests/pickle/src/common_pkg.sv
+++ b/tests/pickle/src/common_pkg.sv
@@ -1,5 +1,7 @@
 package common_pkg;
 
+    parameter int unsigned NumStates = 3;
+
     typedef enum logic [1:0] {
         Idle = 2'b00,
         Busy = 2'b01,

--- a/tests/pickle/src/core.sv
+++ b/tests/pickle/src/core.sv
@@ -1,5 +1,8 @@
 module core #(
     parameter common_pkg::state_t DefaultState = common_pkg::Idle
 ) ();
+    // Scoped type name carrying a packed dimension that is itself a scoped name.
+    common_pkg::state_t [common_pkg::NumStates-1:0] state_history;
+
     leaf u_leaf();
 endmodule


### PR DESCRIPTION
Fixes https://github.com/pulp-platform/bender/issues/338

Rewritting recursively with slang is a bit difficult with slang, since it does not persist for nested scoped names when replacing the syntax node. There is a helper function`rewrite_scoped_names_inplace` which solves this, but it was simply missing for this particular case. I added some regression tests as well.