### PR TITLE
build: add x86_64 musl binaries

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -32,6 +32,10 @@ jobs:
             runner: ubuntu-22.04-arm
             container: quay.io/pypa/manylinux_2_28_aarch64
             cache_golden_bin: false
+          - target: x86_64-unknown-linux-musl
+            runner: ubuntu-22.04
+            container: quay.io/pypa/musllinux_1_2_x86_64
+            cache_golden_bin: false
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-latest
             cache_golden_bin: true

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -10,7 +10,7 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether to install an updater program
@@ -30,3 +30,6 @@ container = "quay.io/pypa/manylinux_2_28_x86_64"
 [dist.github-custom-runners.aarch64-unknown-linux-gnu]
 runner = "ubuntu-22.04-arm"
 container = "quay.io/pypa/manylinux_2_28_aarch64"
+[dist.github-custom-runners.x86_64-unknown-linux-musl]
+runner = "ubuntu-22.04"
+container = { image = "quay.io/pypa/musllinux_1_2_x86_64", host = "x86_64-unknown-linux-musl" }


### PR DESCRIPTION
Adds Linux x86_64 binaries that link against musl instead of glibc. The advantage of that is that those are fully statically linked libraries so they are more portable e.g. to Linux distros with glibc versions lower than the manylinux container that we currently use or minimal containers without glibc at all.

The installer script will still install gnu based binaries if a compatible glibc is detected and fall back to musl builds otherwise.

I also tried adding ARM musl binaries, but it is much more complicated to set up with the current github runners (requires cross compilation and other things), which is why I decided to drop it.

## Verification

Release build passed in https://github.com/pulp-platform/bender/actions/runs/31378434929. I also tested the built artifact on my workstation with a couple of commands incl. slang based features.