### PR TITLE
Fix a bug of $ROOT path when using path dependency

### DIFF
--- a/src/script_fmt/formality_tcl.tera
+++ b/src/script_fmt/formality_tcl.tera
@@ -5,7 +5,7 @@ set search_path_initial $search_path
 {% if compilation_mode == 'separate' %}{% for group in srcs %}{% if group.file_type == 'verilog' or group.file_type == 'vhdl' %}{% if source_annotations %}
 # {{ group.metadata }}{% endif %}
 set search_path $search_path_initial
-{% for incdir in group.incdirs %}lappend search_path "$ROOT{{ incdir | replace(from=root, to='') }}"
+{% for incdir in group.incdirs %}lappend search_path "${ROOT}{{ incdir | replace(from=root, to='') }}"
 {% endfor %}
 {% if abort_on_error %}if {[catch { {% endif %}{% if group.file_type == 'verilog' %}read_sverilog{% elif group.file_type == 'vhdl' %}read_vhdl{% endif %} -r \
     {% for define in group.defines %}{% if loop.first %}-define { \
@@ -14,19 +14,19 @@ set search_path $search_path_initial
     {% else %} \
         {% endif %}{% endfor %}[list \
     {% for file in group.files %}{% if source_annotations %}{% if file.comment %}{{ '    ' }}# {{ file.comment }}
-    {% endif %}{% endif %}{{ '    ' }}"{{ file.file | replace(from=root, to='$ROOT') }}" \
+    {% endif %}{% endif %}{{ '    ' }}"{{ file.file | replace(from=root, to='${ROOT}') }}" \
     {% endfor %}]
 {% if abort_on_error %}}]} {return 1}{% endif %}
 {% else %}{% if source_annotations %}
 # {{ group.metadata }}{% endif %}
 # Skipping {{ group.files | length }} file(s) of unknown type (prefix with sv:/v:/vhd: to set one):
-{% for file in group.files %}#   {{ file.file | replace(from=root, to='$ROOT') }}
+{% for file in group.files %}#   {{ file.file | replace(from=root, to='${ROOT}') }}
 {% endfor %}{% endif %}{% endfor %}
 {# Common compilation: all files in one block -#}
 {% else -%}
 {# Verilog sources -#}
 {%- for file in all_verilog %}{% if loop.first %}set search_path $search_path_initial
-{% for incdir in all_incdirs %}lappend search_path "$ROOT{{ incdir | replace(from=root, to='') }}"
+{% for incdir in all_incdirs %}lappend search_path "${ROOT}{{ incdir | replace(from=root, to='') }}"
 {% endfor %}
 {% if abort_on_error %}if {[catch { {% endif %}read_sverilog -r \
     {% for define in all_defines %}{% if loop.first %}-define { \
@@ -35,7 +35,7 @@ set search_path $search_path_initial
     {% else %} \
         {% endif %}{% endfor %}[list \
     {% endif %}{% if source_annotations %}{% if file.comment %}{{ '    ' }}# {{ file.comment }}
-    {% endif %}{% endif %}{{ '    ' }}"{{ file.file | replace(from=root, to='$ROOT') }}" \
+    {% endif %}{% endif %}{{ '    ' }}"{{ file.file | replace(from=root, to='${ROOT}') }}" \
     {% if loop.last %}]
 {% if abort_on_error %}}]} {return 1}{% endif %}
 {% endif %}{% endfor %}
@@ -43,7 +43,7 @@ set search_path $search_path_initial
 {% for file in all_vhdl %}{% if loop.first %}{% if abort_on_error %}if {[catch { {% endif %}read_vhdl -r \
     [list \
     {% endif %}{% if source_annotations %}{% if file.comment %}{{ '    ' }}# {{ file.comment }}
-    {% endif %}{% endif %}{{ '    ' }}"{{ file.file | replace(from=root, to='$ROOT') }}" \
+    {% endif %}{% endif %}{{ '    ' }}"{{ file.file | replace(from=root, to='${ROOT}') }}" \
     {% if loop.last %}]
 {% if abort_on_error %}}]} {return 1}{% endif %}
 {% endif %}{% endfor %}

--- a/src/script_fmt/genus_tcl.tera
+++ b/src/script_fmt/genus_tcl.tera
@@ -9,7 +9,7 @@ set ROOT "{{ root }}"
 {% if compilation_mode == 'separate' %}{% for group in srcs %}{% if group.file_type == 'verilog' or group.file_type == 'vhdl' %}{% if source_annotations %}
 # {{ group.metadata }}{% endif %}
 set search_path $search_path_initial
-{% for incdir in group.incdirs %}lappend search_path "{{ incdir | replace(from=root, to='$ROOT') }}"
+{% for incdir in group.incdirs %}lappend search_path "{{ incdir | replace(from=root, to='${ROOT}') }}"
 {% endfor %}set_db init_hdl_search_path $search_path
 
 {% if group.file_type == 'verilog' %}read_hdl -language sv \
@@ -20,18 +20,18 @@ set search_path $search_path_initial
     {% else %} \
         {% endif %}{% endfor %}[list \
     {% for file in group.files %}{% if source_annotations %}{% if file.comment %}{{ '    ' }}# {{ file.comment }}
-    {% endif %}{% endif %}{{ '    ' }}"{{ file.file | replace(from=root, to='$ROOT') }}" \
+    {% endif %}{% endif %}{{ '    ' }}"{{ file.file | replace(from=root, to='${ROOT}') }}" \
     {% endfor %}]
 {% else %}{% if source_annotations %}
 # {{ group.metadata }}{% endif %}
 # Skipping {{ group.files | length }} file(s) of unknown type (prefix with sv:/v:/vhd: to set one):
-{% for file in group.files %}#   {{ file.file | replace(from=root, to='$ROOT') }}
+{% for file in group.files %}#   {{ file.file | replace(from=root, to='${ROOT}') }}
 {% endfor %}{% endif %}{% endfor %}
 {# Common compilation: all files in one block -#}
 {% else -%}
 {# Verilog sources -#}
 {%- for file in all_verilog %}{% if loop.first %}set search_path $search_path_initial
-{% for incdir in all_incdirs %}lappend search_path "$ROOT{{ incdir | replace(from=root, to='') }}"
+{% for incdir in all_incdirs %}lappend search_path "${ROOT}{{ incdir | replace(from=root, to='') }}"
 {% endfor %}
 set_db init_hdl_search_path $search_path
 
@@ -42,7 +42,7 @@ set_db init_hdl_search_path $search_path
     {% else %} \
         {% endif %}{% endfor %}[list \
     {% endif %}{% if source_annotations %}{% if file.comment %}{{ '    ' }}# {{ file.comment }}
-    {% endif %}{% endif %}{{ '    ' }}"{{ file.file | replace(from=root, to='$ROOT') }}" \
+    {% endif %}{% endif %}{{ '    ' }}"{{ file.file | replace(from=root, to='${ROOT}') }}" \
     {% if loop.last %}]
 {% if abort_on_error %}}]} {return 1}{% endif %}
 {% endif %}{% endfor %}
@@ -51,7 +51,7 @@ set_db init_hdl_search_path $search_path
 {% if abort_on_error %}if {[catch { {% endif %}read_hdl -language vhdl \
     [list \
     {% endif %}{% if source_annotations %}{% if file.comment %}{{ '    ' }}# {{ file.comment }}
-    {% endif %}{% endif %}{{ '    ' }}"{{ file.file | replace(from=root, to='$ROOT') }}" \
+    {% endif %}{% endif %}{{ '    ' }}"{{ file.file | replace(from=root, to='${ROOT}') }}" \
     {% if loop.last %}]
 {% if abort_on_error %}}]} {return 1}{% endif %}
 {% endif %}{% endfor %}

--- a/src/script_fmt/riviera_tcl.tera
+++ b/src/script_fmt/riviera_tcl.tera
@@ -6,17 +6,17 @@ vlib work
 {% endif %}{% if abort_on_error %}if {[catch { {% endif %}{% if group.file_type == 'verilog' %}vlog -sv \
     {% for tmp_arg in vlog_args %}{{ tmp_arg }} \
     {% endfor %}{% for define in group.defines %}"+define+{{ define[0] }}{% if define[1] %}={{ define[1] }}{% endif %}" \
-    {% endfor %}{% for incdir in group.incdirs %}"+incdir+{{ incdir | replace(from=root, to='$ROOT') }}" \
+    {% endfor %}{% for incdir in group.incdirs %}"+incdir+{{ incdir | replace(from=root, to='${ROOT}') }}" \
     {% endfor %}{% elif group.file_type == 'vhdl' %}vcom -2008 \
     {% for tmp_arg in vcom_args %}{{ tmp_arg }} \
     {% endfor %}{% endif %}{% for file in group.files %}{% if source_annotations %}{% if file.comment %}# {{ file.comment }}
-    {% endif %}{% endif %}"{{ file.file | replace(from=root, to='$ROOT') }}" {% if not loop.last %}\
+    {% endif %}{% endif %}"{{ file.file | replace(from=root, to='${ROOT}') }}" {% if not loop.last %}\
     {% else %}\
 {% endif %}{% endfor %}{% if abort_on_error %}}]} {return 1}{% endif %}
 
 {% else %}{% if source_annotations %}# {{ group.metadata }}
 {% endif %}# Skipping {{ group.files | length }} file(s) of unknown type (prefix with sv:/v:/vhd: to set one):
-{% for file in group.files %}#   {{ file.file | replace(from=root, to='$ROOT') }}
+{% for file in group.files %}#   {{ file.file | replace(from=root, to='${ROOT}') }}
 {% endfor %}
 {% endif %}{% endfor -%}
 {# Common compilation: all files in one block -#}
@@ -25,9 +25,9 @@ vlib work
 {%- for file in all_verilog %}{% if loop.first %}{% if abort_on_error %}if {[catch { {% endif %}vlog -sv \
     {% for tmp_arg in vlog_args %}{{ tmp_arg }} \
     {% endfor %}{% for define in all_defines %}"+define+{{ define[0] }}{% if define[1] %}={{ define[1] }}{% endif %}" \
-    {% endfor %}{% for incdir in all_incdirs %}"+incdir+{{ incdir | replace(from=root, to='$ROOT') }}" \
+    {% endfor %}{% for incdir in all_incdirs %}"+incdir+{{ incdir | replace(from=root, to='${ROOT}') }}" \
     {% endfor %}{% endif %}{% if source_annotations %}{% if file.comment %}# {{ file.comment }}
-    {% endif %}{% endif %}"{{ file.file | replace(from=root, to='$ROOT') }}" {% if not loop.last %}\
+    {% endif %}{% endif %}"{{ file.file | replace(from=root, to='${ROOT}') }}" {% if not loop.last %}\
     {% else %}\
 {% endif %}{% if loop.last %}{% if abort_on_error %}}]} {return 1}{% endif %}
 
@@ -36,7 +36,7 @@ vlib work
 {%- for file in all_vhdl %}{% if loop.first %}{% if abort_on_error %}if {[catch { {% endif %}vcom -2008 \
     {% for tmp_arg in vcom_args %}{{ tmp_arg }} \
     {% endfor %}{% endif %}{% if source_annotations %}{% if file.comment %}# {{ file.comment }}
-    {% endif %}{% endif %}"{{ file.file | replace(from=root, to='$ROOT') }}" {% if not loop.last %}\
+    {% endif %}{% endif %}"{{ file.file | replace(from=root, to='${ROOT}') }}" {% if not loop.last %}\
     {% else %}\
 {% endif %}{% if loop.last %}{% if abort_on_error %}}]} {return 1}{% endif %}
 

--- a/src/script_fmt/synopsys_tcl.tera
+++ b/src/script_fmt/synopsys_tcl.tera
@@ -7,7 +7,7 @@ set search_path_initial $search_path
 # {{ group.metadata }}{% endif %}
 set search_path $search_path_initial
 {% for incdir in group.incdirs -%}
-lappend search_path "{{ incdir | replace(from=root, to='$ROOT') }}"
+lappend search_path "{{ incdir | replace(from=root, to='${ROOT}') }}"
 {% endfor %}
 {% if abort_on_error %}if {0 == [{% endif -%}
 analyze -format {% if group.file_type == 'verilog' %}sv{% elif group.file_type == 'vhdl' %}vhdl{% endif %} \
@@ -26,13 +26,13 @@ analyze -format {% if group.file_type == 'verilog' %}sv{% elif group.file_type =
         {% endif %}{% endfor %}[list \
     {% for file in group.files -%}
 {%- if source_annotations %}{% if file.comment %}{{ '    ' }}# {{ file.comment }}
-{% endif %}{% endif %}{{ '    ' }}"{{ file.file | replace(from=root, to='$ROOT') }}" \
+{% endif %}{% endif %}{{ '    ' }}"{{ file.file | replace(from=root, to='${ROOT}') }}" \
     {% endfor %}]
 {% if abort_on_error %}]} {return 1}{% endif %}
 {% else %}{% if source_annotations %}
 # {{ group.metadata }}{% endif %}
 # Skipping {{ group.files | length }} file(s) of unknown type (prefix with sv:/v:/vhd: to set one):
-{% for file in group.files %}#   {{ file.file | replace(from=root, to='$ROOT') }}
+{% for file in group.files %}#   {{ file.file | replace(from=root, to='${ROOT}') }}
 {% endfor %}{% endif %}{% endfor %}
 {# Common compilation: all files in one block -#}
 {% else -%}
@@ -40,7 +40,7 @@ analyze -format {% if group.file_type == 'verilog' %}sv{% elif group.file_type =
 {%- for file in all_verilog -%}
 {%- if loop.first %}set search_path $search_path_initial
 {% for incdir in all_incdirs -%}
-lappend search_path "{{ incdir | replace(from=root, to='$ROOT') }}"
+lappend search_path "{{ incdir | replace(from=root, to='${ROOT}') }}"
 {% endfor %}
 {% if abort_on_error %}if {0 == [{% endif -%}
 analyze -format sv \
@@ -53,7 +53,7 @@ analyze -format sv \
     {% else %} \
         {% endif %}{% endfor %}[list \
     {% endif %}{% if source_annotations %}{% if file.comment %}{{ '    ' }}# {{ file.comment }}
-    {% endif %}{% endif %}{{ '    ' }}"{{ file.file | replace(from=root, to='$ROOT') }}" \
+    {% endif %}{% endif %}{{ '    ' }}"{{ file.file | replace(from=root, to='${ROOT}') }}" \
     {% if loop.last %}]
 {% if abort_on_error %}]} {return 1}{% endif %}
 {% endif %}{% endfor %}
@@ -65,7 +65,7 @@ analyze -format vhdl \
 {% endfor -%}
     [list \
     {% endif %}{% if source_annotations %}{% if file.comment %}{{ '    ' }}# {{ file.comment }}
-    {% endif %}{% endif %}{{ '    ' }}"{{ file.file | replace(from=root, to='$ROOT') }}" \
+    {% endif %}{% endif %}{{ '    ' }}"{{ file.file | replace(from=root, to='${ROOT}') }}" \
     {% if loop.last %}]
 {% if abort_on_error %}]} {return 1}{% endif %}
 {% endif %}{% endfor %}

--- a/src/script_fmt/vcs_sh.tera
+++ b/src/script_fmt/vcs_sh.tera
@@ -11,15 +11,15 @@ ROOT="{{ root }}"
     -full64 \
     {% for tmp_arg in vlogan_args %}{{ tmp_arg }} \
     {% endfor %}{% for define in group.defines %}"+define+{{ define[0] }}{% if define[1] %}={{ define[1] }}{% endif %}" \
-    {% endfor %}{% for incdir in group.incdirs %}"+incdir+{{ incdir | replace(from=root, to='$ROOT') }}" \
+    {% endfor %}{% for incdir in group.incdirs %}"+incdir+{{ incdir | replace(from=root, to='${ROOT}') }}" \
     {% endfor %}{% elif group.file_type == 'vhdl' %}{{ vhdlan_bin }} \
     {% for tmp_arg in vhdlan_args %}{{ tmp_arg }} \
-    {% endfor %}{% endif %}{% for file in group.files %}"{{ file.file | replace(from=root, to='$ROOT') }}" {% if not loop.last %}\
+    {% endfor %}{% endif %}{% for file in group.files %}"{{ file.file | replace(from=root, to='${ROOT}') }}" {% if not loop.last %}\
     {% endif %}{% endfor %}
 {% else %}{% if source_annotations %}
 # {{ group.metadata }}{% endif %}
 # Skipping {{ group.files | length }} file(s) of unknown type (prefix with sv:/v:/vhd: to set one):
-{% for file in group.files %}#   {{ file.file | replace(from=root, to='$ROOT') }}
+{% for file in group.files %}#   {{ file.file | replace(from=root, to='${ROOT}') }}
 {% endfor %}{% endif %}{% endfor %}
 {# Common compilation: all files in one block -#}
 {% else -%}
@@ -28,14 +28,14 @@ ROOT="{{ root }}"
     -full64 \
     {% for tmp_arg in vlogan_args %}{{ tmp_arg }} \
     {% endfor %}{% for define in all_defines %}"+define+{{ define[0] }}{% if define[1] %}={{ define[1] }}{% endif %}" \
-    {% endfor %}{% for incdir in all_incdirs %}"+incdir+{{ incdir | replace(from=root, to='$ROOT') }}" \
-    {% endfor %}{% endif %}"{{ file.file | replace(from=root, to='$ROOT') }}" {% if not loop.last %}\
+    {% endfor %}{% for incdir in all_incdirs %}"+incdir+{{ incdir | replace(from=root, to='${ROOT}') }}" \
+    {% endfor %}{% endif %}"{{ file.file | replace(from=root, to='${ROOT}') }}" {% if not loop.last %}\
     {% endif %}{% if loop.last %}
 {% endif %}{% endfor %}
 {# VHDL sources -#}
 {% for file in all_vhdl %}{% if loop.first %}{{ vhdlan_bin }} \
     {% for tmp_arg in vhdlan_args %}{{ tmp_arg }} \
-    {% endfor %}{% endif %}"{{ file.file | replace(from=root, to='$ROOT') }}" {% if not loop.last %}\
+    {% endfor %}{% endif %}"{{ file.file | replace(from=root, to='${ROOT}') }}" {% if not loop.last %}\
     {% endif %}{% if loop.last %}
 {% endif %}{% endfor %}
 {% endif %}

--- a/src/script_fmt/vivado_tcl.tera
+++ b/src/script_fmt/vivado_tcl.tera
@@ -6,7 +6,7 @@ set ROOT "{{ root }}"
 {% if source_annotations %}# {{ group.metadata }}
 {% endif %}add_files -norecurse -fileset [current_fileset] [list \
     {% for file in group.files %}{% if source_annotations %}{% if file.comment %}# {{ file.comment }}
-    {% endif %}{% endif %}{{ file.file | replace(from=root, to='$ROOT') }} \
+    {% endif %}{% endif %}{{ file.file | replace(from=root, to='${ROOT}') }} \
 {% if not loop.last %}    {% endif %}{% endfor %}]
 {% endfor -%}
 {# Common compilation: all files in one block -#}
@@ -14,7 +14,7 @@ set ROOT "{{ root }}"
 {%- for file in all_files -%}
 {%- if loop.first %}add_files -norecurse -fileset [current_fileset] [list \
     {% endif %}{% if source_annotations %}{% if file.comment %}# {{ file.comment }}
-    {% endif %}{% endif %}{{ file.file | replace(from=root, to='$ROOT') }} \
+    {% endif %}{% endif %}{{ file.file | replace(from=root, to='${ROOT}') }} \
 {% if not loop.last %}    {% endif %}{% if loop.last %}]
 {% endif %}{% endfor %}{% endif -%}
 {# Set include directories and defines for each fileset -#}
@@ -22,7 +22,7 @@ set ROOT "{{ root }}"
 {%- for incdir in all_incdirs -%}
 {%- if loop.first %}
 set_property include_dirs [list \
-    {% endif %}{{incdir | replace(from=root, to='$ROOT') }}{%if loop.last %} \
+    {% endif %}{{incdir | replace(from=root, to='${ROOT}') }}{%if loop.last %} \
 ] [current_fileset{{ arg }}]
 {% else %} \
     {% endif %}{% endfor %}{% endfor -%}

--- a/src/script_fmt/vsim_tcl.tera
+++ b/src/script_fmt/vsim_tcl.tera
@@ -11,7 +11,7 @@ set ROOT "{{ root }}"
     {% endfor -%}
 {%- for define in group.defines %}"+define+{{ define[0] }}{% if define[1] %}={{ define[1] }}{% endif %}" \
     {% endfor -%}
-{%- for incdir in group.incdirs %}"+incdir+{{ incdir | replace(from=root, to='$ROOT') }}" \
+{%- for incdir in group.incdirs %}"+incdir+{{ incdir | replace(from=root, to='${ROOT}') }}" \
     {% endfor -%}
 {%- elif group.file_type == 'vhdl' %}vcom -2008 \
     {% for tmp_arg in vcom_args %}{{ tmp_arg }} \
@@ -19,7 +19,7 @@ set ROOT "{{ root }}"
 {%- endif -%}
 {%- for file in group.files -%}
 {%- if source_annotations %}{% if file.comment %}# {{ file.comment }}
-    {% endif %}{% endif %}"{{ file.file | replace(from=root, to='$ROOT') }}" {% if not loop.last %}\
+    {% endif %}{% endif %}"{{ file.file | replace(from=root, to='${ROOT}') }}" {% if not loop.last %}\
     {% endif -%}
 {%- endfor -%}
 {%- if abort_on_error %}\
@@ -28,7 +28,7 @@ set ROOT "{{ root }}"
 {% if source_annotations %}# {{ group.metadata }}
 {% endif -%}
 # Skipping {{ group.files | length }} file(s) of unknown type (prefix with sv:/v:/vhd: to set one):
-{% for file in group.files %}#   {{ file.file | replace(from=root, to='$ROOT') }}
+{% for file in group.files %}#   {{ file.file | replace(from=root, to='${ROOT}') }}
 {% endfor -%}
 {% endif %}{% endfor -%}
 {# Common compilation: all files in one block -#}
@@ -41,10 +41,10 @@ vlog -incr -sv \
     {% endfor -%}
 {%- for define in all_defines %}"+define+{{ define[0] }}{% if define[1] %}={{ define[1] }}{% endif %}" \
     {% endfor -%}
-{%- for incdir in all_incdirs %}"+incdir+{{ incdir | replace(from=root, to='$ROOT') }}" \
+{%- for incdir in all_incdirs %}"+incdir+{{ incdir | replace(from=root, to='${ROOT}') }}" \
     {% endfor -%}
 {%- endif %}{% if source_annotations %}{% if file.comment %}# {{ file.comment }}
-    {% endif %}{% endif %}"{{ file.file | replace(from=root, to='$ROOT') }}" {% if not loop.last %}\
+    {% endif %}{% endif %}"{{ file.file | replace(from=root, to='${ROOT}') }}" {% if not loop.last %}\
     {% endif -%}
 {%- if loop.last %}{% if abort_on_error %} \
 }]} {return 1}{% endif %}
@@ -56,7 +56,7 @@ vcom -2008 \
     {% for tmp_arg in vcom_args %}{{ tmp_arg }} \
     {% endfor -%}
 {%- endif %}{% if source_annotations %}{% if file.comment %}# {{ file.comment }}
-    {% endif %}{% endif %}"{{ file.file | replace(from=root, to='$ROOT') }}" {% if not loop.last %}\
+    {% endif %}{% endif %}"{{ file.file | replace(from=root, to='${ROOT}') }}" {% if not loop.last %}\
     {% endif -%}
 {%- if loop.last %}{% if abort_on_error %} \
 }]} {return 1}{% endif %}


### PR DESCRIPTION
## Fix `$ROOT` variable collision in generated build scripts
  (vsim/vcs/riviera/synopsys/genus/formality/vivado)
  
  ### Problem
  
  `bender script <fmt>` emits generated build scripts (Tcl for
  vsim/riviera/synopsys/genus/formality/vivado, shell for vcs) that shorten
  absolute source paths by replacing the invoking package's root directory
  with a script variable, e.g. `$ROOT`. When a dependency is a `path`-type
  dependency that resolves *outside* the invoking package's own directory tree
  (e.g. `{ path: "../some_sibling_pkg" }`), and that sibling directory's name
  happens to share the root directory's name as a **prefix** (e.g. root is
  `.../foo`, sibling is `.../foo_bar`), the generated variable reference
  silently corrupts:

  set ROOT "/path/to/foo"
  ...
  vlog ... "$ROOT_bar/src/some_file.sv" \
  
  Both Tcl and POSIX shell parse `$ROOT_bar` as a reference to a variable
  named `ROOT_bar`, not `$ROOT` followed by literal `_bar`. Since `ROOT_bar`
  is never defined, this raises an "undefined variable" error. Because every
  `vlog`/`vcom` invocation in these templates is wrapped in `if {[catch { ...
  }]} {return 1}` (or the shell equivalent), the error is swallowed and the
  **entire script silently aborts** at that point — no error is printed, and
  everything after it (including the dependency's own sources) is never
  compiled. The only visible symptom is that compilation output stops partway
  through with no error message.

  ### Root cause

  The templates build these paths with Tera's `replace` filter:

  {{ file.file | replace(from=root, to='$ROOT') }}
  
  `replace` performs a plain substring replacement (like Rust's
  `str::replace`), with no awareness of path boundaries. If `root` (e.g.
  `/scratch/.../foo`) occurs as a literal prefix substring of a longer,
  unrelated path (e.g. `/scratch/.../foo_bar/src/x.sv`), it gets replaced
  anyway, and the leftover suffix (`_bar/src/x.sv`) is concatenated directly
  onto `$ROOT` with no boundary — producing `$ROOT_bar/src/x.sv`. Both Tcl and
  shell greedily consume `[A-Za-z0-9_]` characters after an unbraced `$` when
  resolving a variable reference, so `$ROOT_bar` is read as one identifier,
  not `$ROOT` + literal text.

  ### Fix
  
  Use the braced form `${ROOT}` instead of the bare `$ROOT` wherever it's
  emitted into generated scripts. `${ROOT}` is valid, standard syntax in both
  Tcl and POSIX shell for explicitly delimiting a variable name, and correctly
  disambiguates `${ROOT}_bar` as "value of ROOT" + literal `_bar`, matching
  the intended behavior in all cases (including the common case where no
  collision occurs).

  Applied to every `to='$ROOT'` occurrence, and the two literal `"$ROOT{{ ...
  }}"` occurrences in `genus_tcl.tera`/`formality_tcl.tera`, across:

  - `vsim_tcl.tera`
  - `vcs_sh.tera`
  - `riviera_tcl.tera`
  - `synopsys_tcl.tera`
  - `genus_tcl.tera`
  - `formality_tcl.tera`
  - `vivado_tcl.tera`
  
  (`verilator_sh.tera`, `flist.tera`, `flist-plus.tera`, and
  `precision_tcl.tera` don't use this substitution pattern and are
  unaffected.)
  
  ### Repro
  
  - Package `foo` (root) has a `path` dependency `{ path: "../foo_bar" }` (or
  any sibling directory whose name is prefixed by the root directory's own
  name).
  - `bender script vsim` (or vcs/riviera/synopsys/genus/formality/vivado)
  emits a source block for files under `foo_bar` referencing `$ROOT_bar/...`,
  which is undefined.
  - Running the generated script compiles everything up to that point with no
  reported error, then silently stops.
