### PR TITLE
fix(templates): remove defines from VDHL file lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - script: Template errors now report the template name and source location (e.g. `my_format.tera:12:54`), and unknown filters or tests are reported before rendering starts.
 
 ### Fixed
+- script: stop emitting `-define` flags on VHDL compile commands in the `synopsys`, `formality` and `genus` templates (`--compilation-mode separate` only). VHDL has no preprocessor, and some tools error out on the extra option (https://github.com/pulp-platform/bender/issues/350).
 - script: apply `override_files` before validation and the slang pass, so overriding files replace their targets in file-existence checks and in `--top`/`--trim-incdirs` reduction (previously slang saw both the original and the override as duplicate modules); the overridden-file annotation is preserved.
 - pickle: Rename scoped names nested inside a renamed scoped name, such as a packed dimension on a scoped type (`common_pkg::state_t [common_pkg::NumStates-1:0]`). The rewriter now applies renames as token edits rather than replacing whole syntax nodes, which also fixes the same class of missed rename in virtual interface types and package imports (https://github.com/pulp-platform/bender/pull/342).
 

--- a/src/script_fmt/formality_tcl.tera
+++ b/src/script_fmt/formality_tcl.tera
@@ -8,11 +8,11 @@ set search_path $search_path_initial
 {% for incdir in group.incdirs %}lappend search_path "${ROOT}{{ incdir | replace(from=root, to='') }}"
 {% endfor %}
 {% if abort_on_error %}if {[catch { {% endif %}{% if group.file_type == 'verilog' %}read_sverilog{% elif group.file_type == 'vhdl' %}read_vhdl{% endif %} -r \
-    {% for define in group.defines %}{% if loop.first %}-define { \
+    {# VHDL has no preprocessor: never pass defines to read_vhdl #}{% if group.file_type == 'verilog' %}{% for define in group.defines %}{% if loop.first %}-define { \
         {% endif %}{{ define[0] }}{% if define[1] %}={{ define[1] }}{% endif %}{% if loop.last %} \
     } \
     {% else %} \
-        {% endif %}{% endfor %}[list \
+        {% endif %}{% endfor %}{% endif %}[list \
     {% for file in group.files %}{% if source_annotations %}{% if file.comment %}{{ '    ' }}# {{ file.comment }}
     {% endif %}{% endif %}{{ '    ' }}"{{ file.file | replace(from=root, to='${ROOT}') }}" \
     {% endfor %}]

--- a/src/script_fmt/genus_tcl.tera
+++ b/src/script_fmt/genus_tcl.tera
@@ -14,11 +14,11 @@ set search_path $search_path_initial
 
 {% if group.file_type == 'verilog' %}read_hdl -language sv \
     {% elif group.file_type == 'vhdl' %}read_hdl -language vhdl \
-    {% endif %}{% for define in group.defines %}{% if loop.first %}-define { \
+    {% endif %}{# VHDL has no preprocessor: never pass defines to a VHDL read_hdl #}{% if group.file_type == 'verilog' %}{% for define in group.defines %}{% if loop.first %}-define { \
         {% endif %}{{ define[0] }}{% if define[1] %}={{ define[1] }}{% endif %}{% if loop.last %} \
     } \
     {% else %} \
-        {% endif %}{% endfor %}[list \
+        {% endif %}{% endfor %}{% endif %}[list \
     {% for file in group.files %}{% if source_annotations %}{% if file.comment %}{{ '    ' }}# {{ file.comment }}
     {% endif %}{% endif %}{{ '    ' }}"{{ file.file | replace(from=root, to='${ROOT}') }}" \
     {% endfor %}]

--- a/src/script_fmt/synopsys_tcl.tera
+++ b/src/script_fmt/synopsys_tcl.tera
@@ -18,12 +18,14 @@ analyze -format {% if group.file_type == 'verilog' %}sv{% elif group.file_type =
 {%- for tmp_arg in vhdl_args %}{{ tmp_arg }} \
 {% endfor -%}
 {%- endif -%}
+{# VHDL has no preprocessor: never pass defines to a VHDL analyze -#}
+{%- if group.file_type == 'verilog' -%}
 {%- for define in group.defines -%}
 {%- if loop.first %}-define { \
         {% endif %}{{ define[0] }}{% if define[1] %}={{ define[1] }}{% endif %}{% if loop.last %} \
     } \
     {% else %} \
-        {% endif %}{% endfor %}[list \
+        {% endif %}{% endfor %}{% else %}    {% endif %}[list \
     {% for file in group.files -%}
 {%- if source_annotations %}{% if file.comment %}{{ '    ' }}# {{ file.comment }}
 {% endif %}{% endif %}{{ '    ' }}"{{ file.file | replace(from=root, to='${ROOT}') }}" \


### PR DESCRIPTION
VHDL does not have a preprocessor and adding defines to tools can can fail.

Fixes https://github.com/pulp-platform/bender/issues/350

The corresponding `cli_regression` tests fail as expected