### PR TITLE
build: only include necessary files in package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 license = "Apache-2.0 OR MIT"
 edition = "2024"
 rust-version = "1.89.0"
+include = ["src/**/*", "LICENSE-*", "README.md", "CHANGELOG.md"]
 
 [workspace]
 members = ["crates/bender-slang"]


### PR DESCRIPTION
Ran [`cargo diet`](https://github.com/the-lean-crate/cargo-diet) over bender which surfaced some unnecessary files that ar currently packaged alongside the source code. The files removed from the package are mostly tests, documentation and CI worfklows:

```
┌───────────────────────────────────────────────┬─────────────┐
│ Removed File                                  │ Size (Byte) │
├───────────────────────────────────────────────┼─────────────┤
│ tests/cli_regression/src4.e                   │           0 │
│ tests/cli_regression/src3.vhd                 │           0 │
│ tests/cli_regression/src2.sv                  │           0 │
│ tests/cli_regression/src1.sv                  │           0 │
│ .gitmodules                                   │           0 │
│ book/.gitignore                               │           5 │
│ tests/pickle/Bender.lock                      │          13 │
│ tests/pickle/src/leaf.sv                      │          23 │
│ tests/pickle/src/broken.sv                    │          26 │
│ tests/pickle/src/misc_rtl.sv                  │          27 │
│ tests/pickle/src/unused_leaf.sv               │          30 │
│ tests/pickle/src/dup_top.sv                   │          43 │
│ tests/pickle/src/encrypted_top.sv             │          59 │
│ tests/pickle/src/unused_top.sv                │          62 │
│ tests/pickle/src/dup_a.sv                     │         112 │
│ tests/pickle/src/core.sv                      │         116 │
│ .clangd                                       │         121 │
│ tests/pickle/src/named_end.sv                 │         122 │
│ tests/pickle/override/leaf.sv                 │         123 │
│ book/book.toml                                │         123 │
│ tests/pickle/src/dup_b.sv                     │         129 │
│ .gitattributes                                │         145 │
│ .gitignore                                    │         147 │
│ tests/pickle/src/misc_notes.txt               │         153 │
│ tests/pickle/include_unused/unused_header.svh │         184 │
│ .cargo/config.toml.iis                        │         235 │
│ tests/pickle/src/common_pkg.sv                │         239 │
│ tests/pickle/src/encrypted_user.sv            │         280 │
│ .clang-format                                 │         313 │
│ tests/pickle/include/macros.svh               │         319 │
│ tests/pickle/src/bus_intf.sv                  │         373 │
│ tests/pickle/src/encrypted_ip.sv              │         513 │
│ tests/iss5_checkout_branch_test.sh            │         595 │
│ tests/iss2_empty_dep_test.sh                  │         612 │
│ tests/cli_regression/Bender.yml               │         623 │
│ .github/dependabot.yml                        │         626 │
│ tests/cli_regression/Bender.lock              │         661 │
│ book/src/SUMMARY.md                           │         766 │
│ .github/workflows/formatting.yml              │         773 │
│ tests/pickle/Bender.yml                       │         792 │
│ book/src/workflows.md                         │         828 │
│ book/src/workflow/init.md                     │         878 │
│ book/src/concepts.md                          │        1023 │
│ .github/workflows/docs.yml                    │        1032 │
│ tests/pickle/src/top.sv                       │        1044 │
│ tests/run_all.sh                              │        1192 │
│ dist-workspace.toml                           │        1274 │
│ .github/workflows/cli_regression.yml          │        1448 │
│ book/src/getting_started.md                   │        1693 │
│ book/src/index.md                             │        1852 │
│ .github/workflows/ci.yml                      │        1923 │
│ flake.lock                                    │        1927 │
│ book/src/bender_files.md                      │        2129 │
│ book/src/principles.md                        │        2196 │
│ tests/iss290_audit_path_conflict_test.sh      │        2344 │
│ book/src/lockfile.md                          │        2628 │
│ .github/workflows/release-build.yml           │        3018 │
│ book/src/workflow/package_dev.md              │        3135 │
│ flake.nix                                     │        3173 │
│ book/src/local.md                             │        3263 │
│ website/init                                  │        3795 │
│ book/src/workflow/vendor.md                   │        4036 │
│ book/src/sources.md                           │        4403 │
│ book/src/installation.md                      │        4701 │
│ book/src/workflow/dependencies.md             │        4987 │
│ book/src/workflow/ci.md                       │        4987 │
│ book/src/workflow/scripts.md                  │        5352 │
│ book/src/manifest.md                          │        6048 │
│ book/src/configuration.md                     │        6192 │
│ tests/pickle.rs                               │        6258 │
│ book/src/dependencies.md                      │        6371 │
│ book/src/targets.md                           │        6561 │
│ tests/cli_regression.rs                       │        8701 │
│ website/pulp_logo_icon.svg                    │       12221 │
│ .github/workflows/release.yml                 │       12402 │
│ website/init-legacy                           │       13090 │
│ book/src/commands.md                          │       17306 │
│ tests/script.rs                               │       21417 │
└───────────────────────────────────────────────┴─────────────┘
Saved 25% or 196.3 kB in 78 files (of 796.2 kB and 126 files in entire crate)
```

`cargo package` also still works