### PR TITLE
refactor(bender-slang)!: pass slices instead of vectors across FFI

### DIFF
--- a/crates/bender-slang/cpp/analysis.cpp
+++ b/crates/bender-slang/cpp/analysis.cpp
@@ -53,7 +53,7 @@ rust::Vec<ParsedTree> all_trees(const SlangSession& session) {
     return out;
 }
 
-rust::Vec<ParsedTree> reachable_trees(const SlangSession& session, const rust::Vec<rust::String>& tops) {
+rust::Vec<ParsedTree> reachable_trees(const SlangSession& session, rust::Slice<const rust::String> tops) {
     const auto& entries = session.entries();
 
     // One engine+client per distinct SourceManager. Each parse group creates its own

--- a/crates/bender-slang/cpp/rewriter.cpp
+++ b/crates/bender-slang/cpp/rewriter.cpp
@@ -186,7 +186,7 @@ void SyntaxTreeRewriter::set_prefix(rust::Str value) { prefix = std::string(valu
 
 void SyntaxTreeRewriter::set_suffix(rust::Str value) { suffix = std::string(value.data(), value.size()); }
 
-void SyntaxTreeRewriter::set_excludes(const rust::Vec<rust::String> values) {
+void SyntaxTreeRewriter::set_excludes(rust::Slice<const rust::String> values) {
     excludes.clear();
     for (const auto& value : values) {
         excludes.insert(std::string(value));

--- a/crates/bender-slang/cpp/session.cpp
+++ b/crates/bender-slang/cpp/session.cpp
@@ -19,7 +19,7 @@ SlangContext::SlangContext() : diagEngine(sourceManager), diagClient(std::make_s
     diagEngine.addClient(diagClient);
 }
 
-void SlangContext::set_includes(const rust::Vec<rust::String>& incs) {
+void SlangContext::set_includes(rust::Slice<const rust::String> incs) {
     for (const auto& inc : incs) {
         std::string incStr(inc.data(), inc.size());
         if (auto ec = sourceManager.addUserDirectories(incStr); ec) {
@@ -28,7 +28,7 @@ void SlangContext::set_includes(const rust::Vec<rust::String>& incs) {
     }
 }
 
-void SlangContext::set_defines(const rust::Vec<rust::String>& defs) {
+void SlangContext::set_defines(rust::Slice<const rust::String> defs) {
     ppOptions.predefines.reserve(defs.size());
     for (const auto& def : defs) {
         ppOptions.predefines.emplace_back(def.data(), def.size());
@@ -39,7 +39,7 @@ void SlangContext::set_defines(const rust::Vec<rust::String>& defs) {
 // syntax tree with the per-file facts slang reported (path, parse success, encryption).
 // System-level errors (file unreadable, etc.) throw; per-file parse errors are surfaced
 // non-fatally via the TreeEntry::parsedOk flag so the caller can apply policy.
-std::vector<TreeEntry> SlangContext::parse_files(const rust::Vec<rust::String>& paths) {
+std::vector<TreeEntry> SlangContext::parse_files(rust::Slice<const rust::String> paths) {
     Bag options;
     options.set(ppOptions);
 
@@ -88,8 +88,8 @@ std::vector<TreeEntry> SlangContext::parse_files(const rust::Vec<rust::String>& 
 
 // Parses a group of files with the given include paths and preprocessor defines.
 // Stores the resulting syntax trees and contexts in the session for later retrieval and analysis.
-void SlangSession::parse_group(const rust::Vec<rust::String>& files, const rust::Vec<rust::String>& includes,
-                               const rust::Vec<rust::String>& defines) {
+void SlangSession::parse_group(rust::Slice<const rust::String> files, rust::Slice<const rust::String> includes,
+                               rust::Slice<const rust::String> defines) {
     // Create a new context for this group of files.
     auto ctx = std::make_unique<SlangContext>();
     ctx->set_includes(includes);

--- a/crates/bender-slang/cpp/slang_bridge.h
+++ b/crates/bender-slang/cpp/slang_bridge.h
@@ -43,10 +43,10 @@ class SlangContext {
   public:
     SlangContext();
 
-    void set_includes(const rust::Vec<rust::String>& includes);
-    void set_defines(const rust::Vec<rust::String>& defines);
+    void set_includes(rust::Slice<const rust::String> includes);
+    void set_defines(rust::Slice<const rust::String> defines);
 
-    std::vector<TreeEntry> parse_files(const rust::Vec<rust::String>& paths);
+    std::vector<TreeEntry> parse_files(rust::Slice<const rust::String> paths);
 
   private:
     slang::SourceManager sourceManager;
@@ -57,8 +57,8 @@ class SlangContext {
 
 class SlangSession {
   public:
-    void parse_group(const rust::Vec<rust::String>& files, const rust::Vec<rust::String>& includes,
-                     const rust::Vec<rust::String>& defines);
+    void parse_group(rust::Slice<const rust::String> files, rust::Slice<const rust::String> includes,
+                     rust::Slice<const rust::String> defines);
 
     const std::vector<TreeEntry>& entries() const { return treeEntries; }
 
@@ -71,7 +71,7 @@ class SyntaxTreeRewriter {
   public:
     void set_prefix(rust::Str prefix);
     void set_suffix(rust::Str suffix);
-    void set_excludes(const rust::Vec<rust::String> excludes);
+    void set_excludes(rust::Slice<const rust::String> excludes);
 
     std::shared_ptr<slang::syntax::SyntaxTree> rewrite_declarations(std::shared_ptr<slang::syntax::SyntaxTree> tree);
     std::shared_ptr<slang::syntax::SyntaxTree> rewrite_references(std::shared_ptr<slang::syntax::SyntaxTree> tree);
@@ -96,7 +96,7 @@ rust::String print_tree(std::shared_ptr<slang::syntax::SyntaxTree> tree, SlangPr
 rust::String dump_tree_json(std::shared_ptr<slang::syntax::SyntaxTree> tree);
 
 rust::Vec<ParsedTree> all_trees(const SlangSession& session);
-rust::Vec<ParsedTree> reachable_trees(const SlangSession& session, const rust::Vec<rust::String>& tops);
+rust::Vec<ParsedTree> reachable_trees(const SlangSession& session, rust::Slice<const rust::String> tops);
 rust::Vec<rust::String> resolved_include_paths_for(const rust::Vec<ParsedTree>& trees);
 std::uint64_t renamed_declarations(const SyntaxTreeRewriter& rewriter);
 std::uint64_t renamed_references(const SyntaxTreeRewriter& rewriter);

--- a/crates/bender-slang/src/lib.rs
+++ b/crates/bender-slang/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 ETH Zurich
 // Tim Fischer <fischeti@iis.ee.ethz.ch>
 
-use std::marker::PhantomData;
+use std::{borrow::Cow, marker::PhantomData};
 
 use cxx::{SharedPtr, UniquePtr};
 use thiserror::Error;
@@ -63,20 +63,20 @@ mod ffi {
 
         fn parse_group(
             self: Pin<&mut SlangSession>,
-            files: &Vec<String>,
-            includes: &Vec<String>,
-            defines: &Vec<String>,
+            files: &[String],
+            includes: &[String],
+            defines: &[String],
         ) -> Result<()>;
 
         fn all_trees(session: &SlangSession) -> Vec<ParsedTree>;
 
-        fn reachable_trees(session: &SlangSession, tops: &Vec<String>) -> Result<Vec<ParsedTree>>;
+        fn reachable_trees(session: &SlangSession, tops: &[String]) -> Result<Vec<ParsedTree>>;
 
         fn resolved_include_paths_for(trees: &Vec<ParsedTree>) -> Vec<String>;
 
         fn new_syntax_tree_rewriter() -> UniquePtr<SyntaxTreeRewriter>;
         fn set_suffix(self: Pin<&mut SyntaxTreeRewriter>, suffix: &str);
-        fn set_excludes(self: Pin<&mut SyntaxTreeRewriter>, excludes: Vec<String>);
+        fn set_excludes(self: Pin<&mut SyntaxTreeRewriter>, excludes: &[String]);
         fn rewrite_declarations(
             self: Pin<&mut SyntaxTreeRewriter>,
             tree: SharedPtr<SyntaxTree>,
@@ -190,13 +190,11 @@ impl SlangSession {
         includes: &[String],
         defines: &[String],
     ) -> Result<()> {
-        let files_vec = files.to_vec();
-        let includes_vec = normalize_include_dirs(includes)?;
-        let defines_vec = defines.to_vec();
+        let includes = normalize_include_dirs(includes)?;
 
         self.inner
             .pin_mut()
-            .parse_group(&files_vec, &includes_vec, &defines_vec)
+            .parse_group(files, includes.as_ref(), defines)
             .map_err(|cause| SlangError::ParseGroup {
                 message: cause.to_string(),
             })
@@ -214,8 +212,7 @@ impl SlangSession {
     /// Returns the parsed trees reachable from the given top modules, each bundled with its
     /// per-file facts.
     pub fn reachable_trees(&self, tops: &[String]) -> Result<Vec<ParsedTree<'_>>> {
-        let tops = tops.to_vec();
-        let trees = ffi::reachable_trees(self.inner.as_ref().unwrap(), &tops).map_err(|cause| {
+        let trees = ffi::reachable_trees(self.inner.as_ref().unwrap(), tops).map_err(|cause| {
             SlangError::TrimByTop {
                 message: cause.to_string(),
             }
@@ -253,18 +250,16 @@ impl SyntaxTreeRewriter {
         }
     }
 
-    pub fn set_prefix(&mut self, prefix: impl Into<String>) {
-        let prefix = prefix.into();
-        self.inner.pin_mut().set_prefix(&prefix);
+    pub fn set_prefix(&mut self, prefix: &str) {
+        self.inner.pin_mut().set_prefix(prefix);
     }
 
-    pub fn set_suffix(&mut self, suffix: impl Into<String>) {
-        let suffix = suffix.into();
-        self.inner.pin_mut().set_suffix(&suffix);
+    pub fn set_suffix(&mut self, suffix: &str) {
+        self.inner.pin_mut().set_suffix(suffix);
     }
 
-    pub fn set_excludes(&mut self, excludes: Vec<String>) {
-        self.inner.pin_mut().set_excludes(excludes);
+    pub fn set_excludes(&mut self, excludes: impl AsRef<[String]>) {
+        self.inner.pin_mut().set_excludes(excludes.as_ref());
     }
 
     pub fn rewrite_declarations<'a>(&mut self, tree: &SyntaxTree<'a>) -> SyntaxTree<'a> {
@@ -300,7 +295,7 @@ impl Default for SyntaxTreeRewriter {
 }
 
 #[cfg(windows)]
-fn normalize_include_dirs(includes: &[String]) -> Result<Vec<String>> {
+fn normalize_include_dirs(includes: &[String]) -> Result<Cow<'_, [String]>> {
     let mut out = Vec::with_capacity(includes.len());
     for include in includes {
         let canonical = dunce::canonicalize(include).map_err(|cause| SlangError::ParseGroup {
@@ -311,10 +306,10 @@ fn normalize_include_dirs(includes: &[String]) -> Result<Vec<String>> {
         })?;
         out.push(canonical.to_string_lossy().into_owned());
     }
-    Ok(out)
+    Ok(Cow::Owned(out))
 }
 
 #[cfg(unix)]
-fn normalize_include_dirs(includes: &[String]) -> Result<Vec<String>> {
-    Ok(includes.to_vec())
+fn normalize_include_dirs(includes: &[String]) -> Result<Cow<'_, [String]>> {
+    Ok(Cow::Borrowed(includes))
 }

--- a/src/cmd/pickle.rs
+++ b/src/cmd/pickle.rs
@@ -246,8 +246,8 @@ pub fn run(sess: &Session, args: PickleArgs) -> Result<()> {
     };
 
     let mut rewriter = SyntaxTreeRewriter::new();
-    rewriter.set_prefix(args.prefix.unwrap_or_default());
-    rewriter.set_suffix(args.suffix.unwrap_or_default());
+    rewriter.set_prefix(args.prefix.as_deref().unwrap_or_default());
+    rewriter.set_suffix(args.suffix.as_deref().unwrap_or_default());
     rewriter.set_excludes(args.exclude_rename);
 
     // Pass 1: build rename map across all trees.


### PR DESCRIPTION
Generally, all of those are anyway read-only and this gets rid of a few unnecessary re-allocations.